### PR TITLE
Implement indexing returning FFTArrays

### DIFF
--- a/fftarray/tests/test_fft_array.py
+++ b/fftarray/tests/test_fft_array.py
@@ -47,22 +47,27 @@ def test_indexing(tlib, do_jit: bool):
 
     assert np.array_equal(arr_2d.values[0:3:2,:], xr_arr.values[0:3:2,:])
     assert np.array_equal(
-        arr_2d.isel(x=1,y=slice(0,2,None)),
-        xr_arr.isel(x=1,y=slice(0,2,None))
+        arr_2d.isel(x=1,y=slice(0,2,None)).transpose("x", "y"),
+        xr_arr.isel(x=1,y=slice(0,2,None)).expand_dims({"x": 1}).transpose("x", "y")
     )
     assert np.array_equal(
-        arr_2d.sel(x=(1,3),y=3.4, method="nearest"),
+        arr_2d.sel(x=(1,3),y=3.4, method="nearest").transpose("x", "y"),
         xr_arr.sel(y=3.4, method="nearest")
             .where(xr_arr.x > 1, drop=True)
             .where(xr_arr.x < 3, drop=True)
+            .expand_dims({"y": 1}).transpose("x", "y")
     )
 
-    assert np.array_equal(arr_2d.loc[:, 0], xr_arr.loc[:,0])
     assert np.array_equal(
-        arr_2d.loc[(1,3), 2],
+        arr_2d.loc[:, 0].transpose("x", "y").values,
+        xr_arr.loc[:,0].expand_dims({"y": 1}).transpose("x", "y")
+    )
+    assert np.array_equal(
+        arr_2d.loc[(1,3), 2].transpose("x", "y").values,
         xr_arr.sel(y=2)
             .where(xr_arr.x > 1, drop=True)
             .where(xr_arr.x < 3, drop=True)
+            .expand_dims({"y": 1}).transpose("x", "y")
     )
 
     def test_jittable(x_dim, arr_2d):
@@ -80,10 +85,10 @@ def test_indexing(tlib, do_jit: bool):
     jit_res = test_jittable(x_dim=x_dim, arr_2d=arr_2d)
     assert jit_res[0] == 0
     assert jit_res[1] == 2
-    assert np.array_equal(jit_res[2], xr_arr.sel(x=1,y=3.4, method="nearest"))
-    assert np.array_equal(jit_res[3], xr_arr.sel(x=-100,y=3.4, method="nearest"))
+    assert np.array_equal(jit_res[2], xr_arr.sel(x=1,y=3.4, method="nearest").expand_dims({"x": 1, "y": 1}))
+    assert np.array_equal(jit_res[3], xr_arr.sel(x=-100,y=3.4, method="nearest").expand_dims({"x": 1, "y": 1}))
     assert np.array_equal(jit_res[4], xr_arr.loc[:])
-    assert np.array_equal(jit_res[5], xr_arr.isel(x=3, y=2))
+    assert np.array_equal(jit_res[5], xr_arr.isel(x=3, y=2).expand_dims({"x": 1, "y": 1}))
 
 
 @pytest.mark.filterwarnings("ignore")


### PR DESCRIPTION
This has currently a problem of what to do when selecting a range withe length=1 in a dimension.
In `numpy` and `xarray` the array then loses this dimension.
Currently we have the invariant that `len(_dims) == len(_values.shape)`.
This means we would loose our coordinates.
And in the case of selecting a single point we could not create a valid FFTArray anymore because it needs to have at least one dimension. (eg. defining the TensorLib).

We could of course make range indexing a completely different API from single element indexing in the API.
Tuples for ranges is a custom extension of xarray anyways.
Any thoughts?