### PR TITLE
Fix mypy error

### DIFF
--- a/fftarray/backends/jax_backend.py
+++ b/fftarray/backends/jax_backend.py
@@ -20,10 +20,10 @@ class JaxTensorLib(TensorLib):
     def __init__(self, precision: PrecisionSpec = "default"):
         TensorLib.__init__(self, precision = precision)
 
-    def fftn(self, values: ArrayLike) -> jax.Array:
+    def fftn(self, values: ArrayLike) -> jax.Array: # type: ignore[override]
         return jnp.fft.fftn(values)
 
-    def ifftn(self, values: ArrayLike) -> jax.Array:
+    def ifftn(self, values: ArrayLike) -> jax.Array: # type: ignore[override]
         return jnp.fft.ifftn(values)
 
     @property


### PR DESCRIPTION
According to mypy, `jax.typing.ArrayLike` is more specific than `numpy.typing.ArrayLike`. So the implementation of `JaxTensorLib.fftn` violates the Liskov substitution principle. Solution would be to set the agrgument type in `JaxTensorLib.fftn` to `numpy.typing.ArrayLike` or add the flag `# type: ignore[override]`. See https://mypy.readthedocs.io/en/stable/common_issues.html#incompatible-overrides.