### PR TITLE
Fix matterwave mypy error

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ setuptools.setup(
     long_description="",
     long_description_content_type="text/plain",
     url="",
-    packages=["fftarray", "fftarray.backends"],
+    packages=["fftarray"],
     include_package_data=True,
     package_data={"fftarray": ["py.typed"]},
     zip_safe=False,


### PR DESCRIPTION
`__init__.py` needed in `fftarray.backends` otherwise mypy throws a missing import error in the `matterwave` CI.