### PR TITLE
Fix matterwave mypy error - part 2

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ setuptools.setup(
     long_description="",
     long_description_content_type="text/plain",
     url="",
-    packages=["fftarray"],
+    packages=["fftarray", "fftarray.backends"],
     include_package_data=True,
     package_data={"fftarray": ["py.typed"]},
     zip_safe=False,


### PR DESCRIPTION
Pull request #64 actually did not fix the mypy errors in matterwave. Turns out having `fftarray.backends` is needed in the packages in `setup.py` for mypy to work. This is fixed in this part 2.