### PR TITLE
Add atol to prevent failing with 1e-39 versus 0

### DIFF
--- a/fftarray/tests/test_fft_array.py
+++ b/fftarray/tests/test_fft_array.py
@@ -376,19 +376,19 @@ def assert_equal_op(
         if "complex" in str(values.dtype):
             assert_array_almost_equal_nulp_complex(arr_op, values_op, nulp=4)
     else:
-        np.testing.assert_allclose(arr_op, values_op, rtol=rtol)
+        np.testing.assert_allclose(arr_op, values_op, rtol=rtol, atol=1e-38)
 
     _arr_op = op(arr)._values
     if op_forces_factors_applied:
         # _values should have factors applied
-        np.testing.assert_allclose(_arr_op, values_op, rtol=rtol)
+        np.testing.assert_allclose(_arr_op, values_op, rtol=rtol, atol=1e-38)
     else:
         # arr._values can differ from arr.values
         if internal_and_public_values_should_differ(arr):
             with pytest.raises(AssertionError):
                 np.testing.assert_allclose(_arr_op, values_op, rtol=rtol)
         else:
-            np.testing.assert_allclose(_arr_op, values_op, rtol=rtol)
+            np.testing.assert_allclose(_arr_op, values_op, rtol=rtol, atol=1e-38)
 
 
 def assert_array_almost_equal_nulp_complex(x: Any, y: Any, nulp: int):


### PR DESCRIPTION
`test_fftarray_lazyness` fails in my new environment. I was not able to track down which package change from our normal setups triggers this, but the actual failure is that `1e-39` vs. `0` violates the allowed absolute tolerances.
Adding an absolute tolerance to the three asserts which have to be true fixes it for me.
But I am not sure whether that is the best fix.

<details>

<summary>Full Package List from pixi</summary>

```
   Package                        Version      Build               Size       Kind   Source
_libgcc_mutex                  0.1          conda_forge         2.5 KiB    conda  _libgcc_mutex-0.1-conda_forge.tar.bz2
_openmp_mutex                  4.5          2_gnu               23.1 KiB   conda  _openmp_mutex-4.5-2_gnu.tar.bz2
alabaster                      1.0.0                            36.5 KiB   pypi   alabaster-1.0.0-py3-none-any.http.whl
asttokens                      2.4.1                            79.9 KiB   pypi   asttokens-2.4.1-py2.py3-none-any.http.whl
attrs                          24.2.0                           210.7 KiB  pypi   attrs-24.2.0-py3-none-any.http.whl
babel                          2.16.0                           27.6 MiB   pypi   babel-2.16.0-py3-none-any.http.whl
bokeh                          3.6.0                            30.9 MiB   pypi   bokeh-3.6.0-py3-none-any.http.whl
bzip2                          1.0.8        h4bc722e_7          246.9 KiB  conda  bzip2-1.0.8-h4bc722e_7.conda
ca-certificates                2024.8.30    hbcca054_0          155.3 KiB  conda  ca-certificates-2024.8.30-hbcca054_0.conda
certifi                        2024.8.30                        301 KiB    pypi   certifi-2024.8.30-py3-none-any.http.whl
charset_normalizer             3.3.2                            441.6 KiB  pypi   charset_normalizer-3.3.2-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.http.whl
contourpy                      1.3.0                            957.7 KiB  pypi   contourpy-1.3.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.http.whl
decorator                      5.1.1                            22.2 KiB   pypi   decorator-5.1.1-py3-none-any.http.whl
docutils                       0.21.2                           2 MiB      pypi   docutils-0.21.2-py3-none-any.http.whl
exceptiongroup                 1.2.2                            50.1 KiB   pypi   exceptiongroup-1.2.2-py3-none-any.http.whl
executing                      2.1.0                            84.7 KiB   pypi   executing-2.1.0-py2.py3-none-any.http.whl
fastjsonschema                 2.20.0                           77.1 KiB   pypi   fastjsonschema-2.20.0-py3-none-any.http.whl
fftarray                       0.0.5                                       pypi   . (editable)
hypothesis                     6.112.2                          1.4 MiB    pypi   hypothesis-6.112.2-py3-none-any.http.whl
idna                           3.10                             341.9 KiB  pypi   idna-3.10-py3-none-any.http.whl
imagesize                      1.4.1                            30.7 KiB   pypi   imagesize-1.4.1-py2.py3-none-any.http.whl
iniconfig                      2.0.0                            12.7 KiB   pypi   iniconfig-2.0.0-py3-none-any.http.whl
ipython                        8.28.0                           2.5 MiB    pypi   ipython-8.28.0-py3-none-any.http.whl
jax                            0.4.30                           6.9 MiB    pypi   jax-0.4.30-py3-none-any.http.whl
jaxlib                         0.4.30                           283.2 MiB  pypi   jaxlib-0.4.30-cp310-cp310-manylinux2014_x86_64.http.whl
jedi                           0.19.1                           4.3 MiB    pypi   jedi-0.19.1-py2.py3-none-any.http.whl
jinja2                         3.1.4                            479.7 KiB  pypi   jinja2-3.1.4-py3-none-any.http.whl
jsonschema                     4.23.0                           460 KiB    pypi   jsonschema-4.23.0-py3-none-any.http.whl
jsonschema_specifications      2023.12.1                        46.2 KiB   pypi   jsonschema_specifications-2023.12.1-py3-none-any.http.whl
jupyter_core                   5.7.2                            86.3 KiB   pypi   jupyter_core-5.7.2-py3-none-any.http.whl
ld_impl_linux-64               2.43         h712a8e2_1          653.9 KiB  conda  ld_impl_linux-64-2.43-h712a8e2_1.conda
libffi                         3.4.2        h7f98852_5          56.9 KiB   conda  libffi-3.4.2-h7f98852_5.tar.bz2
libgcc                         14.1.0       h77fa898_1          826.5 KiB  conda  libgcc-14.1.0-h77fa898_1.conda
libgcc-ng                      14.1.0       h69a702a_1          50.9 KiB   conda  libgcc-ng-14.1.0-h69a702a_1.conda
libgomp                        14.1.0       h77fa898_1          449.4 KiB  conda  libgomp-14.1.0-h77fa898_1.conda
libnsl                         2.0.1        hd590300_0          32.6 KiB   conda  libnsl-2.0.1-hd590300_0.conda
libsqlite                      3.46.1       hadc24fc_0          844.9 KiB  conda  libsqlite-3.46.1-hadc24fc_0.conda
libuuid                        2.38.1       h0b41bf4_0          32.8 KiB   conda  libuuid-2.38.1-h0b41bf4_0.conda
libzlib                        1.3.1        hb9d3cd8_2          59.5 KiB   conda  libzlib-1.3.1-hb9d3cd8_2.conda
m2r2                           0.3.3.post2                      31.5 KiB   pypi   m2r2-0.3.3.post2-py3-none-any.http.whl
markdown_it_py                 3.0.0                            224.2 KiB  pypi   markdown_it_py-3.0.0-py3-none-any.http.whl
markupsafe                     2.1.5                            68.1 KiB   pypi   markupsafe-2.1.5-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.http.whl
matplotlib_inline              0.1.7                            21.2 KiB   pypi   matplotlib_inline-0.1.7-py3-none-any.http.whl
mdit_py_plugins                0.4.2                            139.8 KiB  pypi   mdit_py_plugins-0.4.2-py3-none-any.http.whl
mdurl                          0.1.2                            22.8 KiB   pypi   mdurl-0.1.2-py3-none-any.http.whl
mistune                        0.8.4                            53 KiB     pypi   mistune-0.8.4-py2.py3-none-any.http.whl
ml_dtypes                      0.5.0                            21.7 MiB   pypi   ml_dtypes-0.5.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.http.whl
mypy                           1.11.2                           40 MiB     pypi   mypy-1.11.2-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.http.whl
mypy_extensions                1.0.0                            9 KiB      pypi   mypy_extensions-1.0.0-py3-none-any.http.whl
myst_parser                    4.0.0                            290.4 KiB  pypi   myst_parser-4.0.0-py3-none-any.http.whl
nbformat                       5.10.4                           279.1 KiB  pypi   nbformat-5.10.4-py3-none-any.http.whl
ncurses                        6.5          he02047a_1          868.2 KiB  conda  ncurses-6.5-he02047a_1.conda
numpy                          2.1.1                            53.3 MiB   pypi   numpy-2.1.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.http.whl
openssl                        3.3.2        hb9d3cd8_0          2.8 MiB    conda  openssl-3.3.2-hb9d3cd8_0.conda
opt_einsum                     3.4.0                            242 KiB    pypi   opt_einsum-3.4.0-py3-none-any.http.whl
packaging                      24.1                             171.6 KiB  pypi   packaging-24.1-py3-none-any.http.whl
pandas                         2.2.3                            42 MiB     pypi   pandas-2.2.3-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.http.whl
parso                          0.8.4                            337.2 KiB  pypi   parso-0.8.4-py2.py3-none-any.http.whl
pexpect                        4.9.0                            186.9 KiB  pypi   pexpect-4.9.0-py2.py3-none-any.http.whl
pillow                         10.4.0                           13.7 MiB   pypi   pillow-10.4.0-cp310-cp310-manylinux_2_28_x86_64.http.whl
platformdirs                   4.3.6                            81.2 KiB   pypi   platformdirs-4.3.6-py3-none-any.http.whl
pluggy                         1.5.0                            65.3 KiB   pypi   pluggy-1.5.0-py3-none-any.http.whl
prompt_toolkit                 3.0.48                           1.3 MiB    pypi   prompt_toolkit-3.0.48-py3-none-any.http.whl
ptyprocess                     0.7.0                            39 KiB     pypi   ptyprocess-0.7.0-py2.py3-none-any.http.whl
pure_eval                      0.2.3                            32.1 KiB   pypi   pure_eval-0.2.3-py3-none-any.http.whl
pyfftw                         0.14.0                           8.5 MiB    pypi   pyfftw-0.14.0-cp310-cp310-manylinux_2_28_x86_64.http.whl
pygments                       2.18.0                           4.2 MiB    pypi   pygments-2.18.0-py3-none-any.http.whl
pytest                         8.3.3                            1.1 MiB    pypi   pytest-8.3.3-py3-none-any.http.whl
python                         3.10.0       h543edf9_3_cpython  29.8 MiB   conda  python-3.10.0-h543edf9_3_cpython.tar.bz2
python_dateutil                2.9.0.post0                      431.2 KiB  pypi   python_dateutil-2.9.0.post0-py2.py3-none-any.http.whl
pytz                           2024.2                           983.5 KiB  pypi   pytz-2024.2-py2.py3-none-any.http.whl
pyyaml                         6.0.2                            2.5 MiB    pypi   pyyaml-6.0.2-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.http.whl
readline                       8.2          h8228510_1          274.9 KiB  conda  readline-8.2-h8228510_1.conda
referencing                    0.35.1                           112.6 KiB  pypi   referencing-0.35.1-py3-none-any.http.whl
requests                       2.32.3                           200.3 KiB  pypi   requests-2.32.3-py3-none-any.http.whl
rpds_py                        0.20.0                           913.2 KiB  pypi   rpds_py-0.20.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.http.whl
scipy                          1.14.1                           125.6 MiB  pypi   scipy-1.14.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.http.whl
setuptools                     75.1.0                           4.1 MiB    pypi   setuptools-75.1.0-py3-none-any.http.whl
six                            1.16.0                           37.1 KiB   pypi   six-1.16.0-py2.py3-none-any.http.whl
snowballstemmer                2.2.0                            767.5 KiB  pypi   snowballstemmer-2.2.0-py2.py3-none-any.http.whl
sortedcontainers               2.4.0                            130 KiB    pypi   sortedcontainers-2.4.0-py2.py3-none-any.http.whl
sphinx                         8.0.2                            14.4 MiB   pypi   sphinx-8.0.2-py3-none-any.http.whl
sphinx_rtd_theme               0.5.1                            3.4 MiB    pypi   sphinx_rtd_theme-0.5.1-py2.py3-none-any.http.whl
sphinxcontrib_applehelp        2.0.0                            233.7 KiB  pypi   sphinxcontrib_applehelp-2.0.0-py3-none-any.http.whl
sphinxcontrib_devhelp          2.0.0                            114 KiB    pypi   sphinxcontrib_devhelp-2.0.0-py3-none-any.http.whl
sphinxcontrib_htmlhelp         2.1.0                            138.2 KiB  pypi   sphinxcontrib_htmlhelp-2.1.0-py3-none-any.http.whl
sphinxcontrib_jsmath           1.0.1                            7.9 KiB    pypi   sphinxcontrib_jsmath-1.0.1-py2.py3-none-any.http.whl
sphinxcontrib_qthelp           2.0.0                            140.3 KiB  pypi   sphinxcontrib_qthelp-2.0.0-py3-none-any.http.whl
sphinxcontrib_serializinghtml  2.0.0                            118.6 KiB  pypi   sphinxcontrib_serializinghtml-2.0.0-py3-none-any.http.whl
sqlite                         3.46.1       h9eae976_0          839.1 KiB  conda  sqlite-3.46.1-h9eae976_0.conda
stack_data                     0.6.3                            73.5 KiB   pypi   stack_data-0.6.3-py3-none-any.http.whl
tk                             8.6.13       noxft_h4845f30_101  3.2 MiB    conda  tk-8.6.13-noxft_h4845f30_101.conda
tomli                          2.0.2                            37.3 KiB   pypi   tomli-2.0.2-py3-none-any.http.whl
tornado                        6.4.1                            1.5 MiB    pypi   tornado-6.4.1-cp38-abi3-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.http.whl
traitlets                      5.14.3                           309.2 KiB  pypi   traitlets-5.14.3-py3-none-any.http.whl
typing_extensions              4.12.2                           148.3 KiB  pypi   typing_extensions-4.12.2-py3-none-any.http.whl
tzdata                         2024a        h8827d51_1          121.3 KiB  conda  tzdata-2024a-h8827d51_1.conda
tzdata                         2024.2                           567 KiB    pypi   tzdata-2024.2-py2.py3-none-any.http.whl
urllib3                        2.2.3                            399 KiB    pypi   urllib3-2.2.3-py3-none-any.http.whl
wcwidth                        0.2.13                           489.3 KiB  pypi   wcwidth-0.2.13-py2.py3-none-any.http.whl
xarray                         2024.9.0                         5.5 MiB    pypi   xarray-2024.9.0-py3-none-any.http.whl
xyzservices                    2024.9.0                         1.4 MiB    pypi   xyzservices-2024.9.0-py3-none-any.http.whl
xz                             5.2.6        h166bdaf_0          408.6 KiB  conda  xz-5.2.6-h166bdaf_0.tar.bz2
z3_solver                      4.13.2.0                         63.1 MiB   pypi   z3_solver-4.13.2.0-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.http.whl
```

</details>
