### PR TITLE
Bump minimum python version to 3.10

### DIFF
--- a/.github/workflows/mypy-pytest.yml
+++ b/.github/workflows/mypy-pytest.yml
@@ -22,10 +22,10 @@ jobs:
       with:
         fetch-depth: 0
         fetch-tags: true
-    - name: Set up Python 3.9
+    - name: Set up Python 3.10
       uses: actions/setup-python@v5
       with:
-        python-version: "3.9"
+        python-version: "3.10"
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ setuptools.setup(
     package_data={"fftarray": ["py.typed"]},
     zip_safe=False,
     classifiers=[],
-    python_requires=">=3.9",
+    python_requires=">=3.10",
     install_requires=[
         "numpy>=1.25",
     ],


### PR DESCRIPTION
numpy, xarray and jax all require this as the minimum version in their current releases and I also encountered a bug with python 3.9 in the pyproject.toml experiments.