### PR TITLE
bump jax to 0.4.30

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ if version == "":
 
 assert "." in version
 
-_jax_packages = ["jax>=0.4.2", "jaxlib"]
+_jax_packages = ["jax>=0.4.30", "jaxlib"]
 _pyFFTW_packages = ["pyFFTW"]
 _helpers = ["z3-solver", "xarray"]
 _dashboards = ["ipython", "bokeh"]


### PR DESCRIPTION
This is the first version with exclusive support for the new CUDA install method.