### PR TITLE
Add defensive copy for .values

### DIFF
--- a/fftarray/backends/backend.py
+++ b/fftarray/backends/backend.py
@@ -86,6 +86,7 @@ class Backend(metaclass=ABCMeta):
             input_factors_applied: Iterable[bool],
             target_factors_applied: Iterable[bool],
             spaces: Iterable[Space],
+            ensure_copy: bool,
         ):
         """
             This function takes all dims so that it has more freedom to optimize the application over all dimensions.
@@ -107,6 +108,9 @@ class Backend(metaclass=ABCMeta):
                 signs=signs,
                 spaces=spaces,
             )
+        else:
+            if ensure_copy:
+                values = self.array(values)
 
         return values
 

--- a/fftarray/fft_array.py
+++ b/fftarray/fft_array.py
@@ -416,13 +416,13 @@ class FFTArray(metaclass=ABCMeta):
             Therefore each call evaluates its lazy state again.
             Use `evaluate_lazy_state` if you want to evaluate it once and reuse it multiple times.
         """
-        # TODO Ensure defensive copy here for the Numpy Backend?
         return self._backend.get_values_with_lazy_factors(
             values=self._values,
             dims=self._dims,
             input_factors_applied=self._factors_applied,
             target_factors_applied=[True]*len(self._dims),
             spaces=self._spaces,
+            ensure_copy=True,
         )
 
     def into(
@@ -474,6 +474,7 @@ class FFTArray(metaclass=ABCMeta):
                 input_factors_applied=self._factors_applied,
                 target_factors_applied=pre_fft_applied,
                 spaces=self._spaces,
+                ensure_copy=False,
             )
             fft_axes = []
             ifft_axes = []
@@ -511,6 +512,7 @@ class FFTArray(metaclass=ABCMeta):
             input_factors_applied=current_factors_applied,
             target_factors_applied=factors_norm,
             spaces=space_norm,
+            ensure_copy=False,
         )
 
         return FFTArray(

--- a/fftarray/tests/test_fft_array.py
+++ b/fftarray/tests/test_fft_array.py
@@ -293,6 +293,28 @@ def test_fftarray_lazyness_reduced(backend, precision, space, eager, factors_app
     assert_dual_operand_fun_equivalence(fftarr, all(fftarr._factors_applied), print)
     assert_fftarray_eager_factors_applied(fftarr, print)
 
+@pytest.mark.parametrize("backend", backends)
+def test_immutability(backend) -> None:
+    xdim = FFTDimension("x", n=4, d_pos=0.1, pos_min=-0.2, freq_min=-2.1)
+    arr = xdim.fft_array(backend=backend("fp64"), space="pos")
+    values = arr.values
+    assert arr.values[0] == -0.2
+    try:
+        # For backends with immutable arrays (e.g. jax), we assume this fails.
+        # In these cases, we skip testing immutability ourself.
+        values[0] = 10
+    except:
+        pass
+
+    assert arr.values[0] == -0.2
+    arr_2 = arr.into("freq").into("pos")
+    values_2 = arr_2.values
+    try:
+        values_2[0] = 10
+    except:
+        pass
+    assert arr_2.values[0] == -0.2
+    
 def assert_basic_lazy_logic(arr, log):
     """Tests whether FFTArray.values is equal to the internal _values for the
     special cases where factors_applied=True, space="pos" and comparing the


### PR DESCRIPTION
Stacked PRs:
 * #118
 * __->__#117


--- --- ---

### Add defensive copy for .values


This ensures that FFTArray stays immutable without accessing internals.

Co-authored-by: Christian Struckmann <56967696+cstruckmann@users.noreply.github.com>
Co-authored-by: Gabriel Müller <51076825+gabmueller@users.noreply.github.com>
