### PR TITLE
Make FFTArray constructor more ergonomic

### DIFF
--- a/fftarray/fft_array.py
+++ b/fftarray/fft_array.py
@@ -73,14 +73,58 @@ class FFTArray(metaclass=ABCMeta):
             values,
             dims: Iterable[FFTDimension],
             space: Union[Space, Iterable[Space]],
-            eager: Union[bool, Iterable[bool]],
-            factors_applied: Union[bool, Iterable[bool]],
-            backend: Backend,
+            backend: Optional[Backend] = None,
+            eager: Optional[Union[bool, Iterable[bool]]] = None,
+            factors_applied: Union[bool, Iterable[bool]] = True,
         ):
         """
-            This constructor is not meant for normal usage.
-            Construct new values via the `fft_array()` function of FFTDimension.
+            Construct a new instance of FFTArray from raw values.
+            For normal usage it is recommended to construct
+            new instances via the `fft_array()` function of FFTDimension
+            since this ensures that the dimension parameters and the
+            values match.
+
+            TODO: Check that this does not copy?
+
+            Parameters
+            ----------
+            values :
+                The values to initialize the `FFTArray` with.
+                For performance reasons they are assumed to not be aliased (or immutable)
+                and therefore do not get copied under any circumstances.
+                The type must fit with the specified backend.
+            dims : Iterable[FFTDimension]
+                The FFTDimensions for each dimension of the passed in values.
+            space: Union[Space, Iterable[Space]]
+                Specify the space of the coordinates and in which space the returned FFTArray is intialized.
+            backend: Optional[Backend]
+                The backend to use for the returned FFTArray.  `None` uses default `NumpyBackend("default")` which can be globally changed.
+                The values are transformed into the appropiate type defined by the backend.
+            eager: Union[bool, Iterable[bool]]
+                The eager-mode to use for the returned FFTArray.  `None` uses default `False` which can be globally changed.
+            factors_applied: Union[bool, Iterable[bool]]
+                Whether the fft-factors are applied are already applied for the various dimensions.
+                For external values this is usually `True` since `False` assumes the internal (and unstable)
+                factors-format.
+
+            Returns
+            -------
+            FFTArray
+                The grid coordinates of the chosen space packed into an FFTArray with self as only dimension.
+
+            See Also
+            --------
+            set_default_backend, get_default_backend
+            set_default_eager, get_default_eager
+            fft_array
         """
+
+        if backend is None:
+            backend = _DEFAULT_BACKEND
+
+        if eager is None:
+            eager = _DEFAULT_EAGER
+
         self._dims = tuple(dims)
         n_dims = len(self._dims)
         self._values = values

--- a/fftarray/tests/test_fft_array.py
+++ b/fftarray/tests/test_fft_array.py
@@ -215,19 +215,37 @@ def test_defaults() -> None:
     assert fftarray.get_default_eager() is False
     assert fftarray.get_default_backend() == NumpyBackend("default")
 
-    xdim = FFTDimension("x", n=4, d_pos=0.1, pos_min=-0.2, freq_min=-2.1)
+    xdim = FFTDimension("x", n=4, d_pos=0.1, pos_min=0., freq_min=0.)
     arr = xdim.fft_array(space="pos")
+    manual_arr = FFTArray(
+        values=0.1*np.arange(4),
+        dims=[xdim],
+        space="pos",
+    )
+    assert (manual_arr==arr).values.all()
     assert arr.eager == (False,)
     assert arr.backend == NumpyBackend(precision="default")
 
     fftarray.set_default_backend(JaxBackend(precision="fp32"))
     arr = xdim.fft_array(space="pos")
+    manual_arr = FFTArray(
+        values=0.1*jnp.arange(4, dtype=jnp.float32),
+        dims=[xdim],
+        space="pos",
+    )
+    assert (manual_arr==arr).values.all()
     assert fftarray.get_default_backend() == JaxBackend(precision="fp32")
     assert arr.eager == (False,)
     assert arr.backend == JaxBackend(precision="fp32")
 
     fftarray.set_default_eager(True)
     arr = xdim.fft_array(space="pos")
+    manual_arr = FFTArray(
+        values=0.1*jnp.arange(4, dtype=jnp.float32),
+        dims=[xdim],
+        space="pos",
+    )
+    assert (manual_arr==arr).values.all()
     assert fftarray.get_default_backend() == JaxBackend(precision="fp32")
     assert arr.eager == (True,)
     assert arr.backend == JaxBackend(precision="fp32")


### PR DESCRIPTION
Stacked PRs:
 * #132
 * __->__#122


--- --- ---

### Make FFTArray constructor more ergonomic


Change arg-order to align with `fft_array` and `into`.
Add defaults for backend and eager using the global defaults.
Set default for factors_applied to True.

Co-authored-by: Christian Struckmann <56967696+cstruckmann@users.noreply.github.com>
