### PR TITLE
Add implementation of `__bool__` which always raises a ValueError.

### DIFF
--- a/fftarray/fft_array.py
+++ b/fftarray/fft_array.py
@@ -181,6 +181,9 @@ class FFTArray(metaclass=ABCMeta):
         str_out += f"\nvalues:\n{self.values}"
         return str_out
 
+    def __bool__(self: FFTArray):
+        raise ValueError("The truth value of an array is ambiguous.")
+
     #--------------------
     # Numpy Interfaces
     #--------------------

--- a/fftarray/tests/test_fft_array.py
+++ b/fftarray/tests/test_fft_array.py
@@ -254,6 +254,11 @@ def check_defaults(dim, backend: Backend, eager: bool) -> None:
     assert arr.eager == (eager,)
     assert arr.backend == backend
 
+def test_bool() -> None:
+    xdim = FFTDimension("x", n=4, d_pos=0.1, pos_min=-0.2, freq_min=-2.1)
+    arr = xdim.fft_array(backend=NumpyBackend(), space="pos")
+    with pytest.raises(ValueError):
+        bool(arr)
 
 def draw_hypothesis_fft_array_values(draw, st_type, shape):
     """Creates multi-dimensional array with shape `shape` whose values are drawn


### PR DESCRIPTION
This mirrors the behavior of numpy with the difference that scalar arrays do ot get any special treatment since those are not a relevant case for FFTArray.
Without this the truthness of FFTArray defaults to 'True' which is surprising and inconsistent with numpy.