### PR TITLE
Add ipykernel to be able to run examples in VS Code

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,7 +47,8 @@ Issues = "https://github.com/QSTheory/fftarray/issues"
 "dashboards" = [
     "fftarray[helpers]",
     "ipython",
-    "bokeh"
+    "bokeh",
+    "ipykernel",
 ]
 "dev" = [
     "fftarray[jax, pyFFTW, helpers, dashboards]",


### PR DESCRIPTION
Otherwise VS Code complains.