### PR TITLE
Split mypy and pytest to make CI run faster

### DIFF
--- a/.github/workflows/mypy.yml
+++ b/.github/workflows/mypy.yml
@@ -1,0 +1,35 @@
+# This workflow will install Python dependencies, run tests and lint with a single version of Python
+# For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-python
+
+name: Type Check
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+        fetch-tags: true
+    - name: Set up Python 3.10
+      uses: actions/setup-python@v5
+      with:
+        python-version: "3.10"
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        python -m pip install -e ".[dev]"
+    - name: Type Check with mypy
+      run: |
+        mypy fftarray examples

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -30,9 +30,6 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         python -m pip install -e ".[dev]"
-    - name: Test with mypy
-      run: |
-        mypy fftarray examples
     - name: Test with pytest
       run: |
         python -m pytest --include-slow


### PR DESCRIPTION
This increases the number of CI minutes due to setting up the environment twice but is a first step to make the CI faster and more modular.