### PR TITLE
Suppress warning and type conversion for single precision in numpy 2.0 and above.

### DIFF
--- a/fftarray/backends/numpy.py
+++ b/fftarray/backends/numpy.py
@@ -15,7 +15,7 @@ class NumpyBackend(Backend):
 
     def fftn(self, values, axes: Sequence[int]) -> Union[NDArray[np.complex64], NDArray[np.complex128]]:
         transformed = np.fft.fftn(values, axes=axes)
-        if self.precision == "fp32":
+        if self.precision == "fp32" and np.lib.NumpyVersion(np.__version__) < "1.28.0":
             warnings.warn(
                 "numpy.fft.fftn always computes in double precision. " +
                 "Since precision was set to fp32 the result is automatically " +
@@ -26,7 +26,7 @@ class NumpyBackend(Backend):
 
     def ifftn(self, values, axes: Sequence[int]) -> Union[NDArray[np.complex64], NDArray[np.complex128]]:
         transformed = np.fft.ifftn(values, axes=axes)
-        if self.precision == "fp32":
+        if self.precision == "fp32" and np.lib.NumpyVersion(np.__version__) < "1.28.0":
             warnings.warn('numpy.fft.ifftn always computes in double precision. Since precision was set to fp32 the result is automatically truncated.')
             return transformed.astype(np.complex64)
         return transformed


### PR DESCRIPTION
Since numpy 2.0, all numpy fft functions support
single precision so the warning is incorrect and
the extra type conversion is unnecessary.