### PR TITLE
Split dev dependencies into check and doc and tweak CI

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -42,7 +42,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          python -m pip install -e ".[dev]"
+          python -m pip install -e ".[doc]"
 
       - name: Pandoc install
         run: sudo apt-get install -y --no-install-recommends pandoc

--- a/.github/workflows/mypy.yml
+++ b/.github/workflows/mypy.yml
@@ -7,14 +7,12 @@ on:
   push:
     branches: [ "main" ]
   pull_request:
-    branches: [ "main" ]
 
 permissions:
   contents: read
 
 jobs:
-  build:
-
+  test:
     runs-on: ubuntu-latest
 
     steps:
@@ -29,7 +27,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        python -m pip install -e ".[dev]"
+        python -m pip install -e ".[check]"
     - name: Type Check with mypy
       run: |
         mypy fftarray examples

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -1,22 +1,19 @@
 # This workflow will install Python dependencies, run tests and lint with a single version of Python
 # For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-python
 
-name: Test suite
+name: Run Pytest via pip
 
 on:
   push:
     branches: [ "main" ]
   pull_request:
-    branches: [ "main" ]
 
 permissions:
   contents: read
 
 jobs:
-  build:
-
+  test:
     runs-on: ubuntu-latest
-
     steps:
     - uses: actions/checkout@v4
       with:
@@ -29,7 +26,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        python -m pip install -e ".[dev]"
+        python -m pip install -e ".[check]"
     - name: Test with pytest
       run: |
         python -m pytest --include-slow

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,11 +50,25 @@ Issues = "https://github.com/QSTheory/fftarray/issues"
     "bokeh",
     "ipykernel",
 ]
+
 "dev" = [
-    "fftarray[jax, pyFFTW, helpers, dashboards]",
+    "fftarray[jax, pyFFTW, helpers, dashboards, check, doc]",
+    "hatch",
+]
+
+"check" = [
+    "fftarray[jax, pyFFTW, helpers]",
     "mypy>=0.910",
     "pytest",
     "hypothesis",
+    "ipython",
+    "nbformat",
+    "bokeh",
+    "pytest-cov",
+]
+
+"doc" = [
+    "fftarray[jax, pyFFTW, helpers]",
     "sphinx>=4.2",
     "sphinx-autodoc-typehints",
     "sphinx-book-theme>=1.0.1",
@@ -65,8 +79,6 @@ Issues = "https://github.com/QSTheory/fftarray/issues"
     "myst-nb",
     "m2r2",
     "matplotlib",
-    "pytest-cov",
-    "hatch",
 ]
 
 
@@ -106,8 +118,10 @@ system-requirements = {cuda = "12"}
 
 [tool.pixi.environments]
 # Recursive optional dependencies are currently ignored by pixi environments: https://github.com/prefix-dev/pixi/issues/2024
-devcuda = ["dev", "jaxcuda", "pyFFTW", "helpers", "dashboards"]
-dev = ["dev", "jax", "pyFFTW", "helpers", "dashboards"]
+devcuda = ["dev", "check", "doc", "jaxcuda", "pyFFTW", "helpers", "dashboards"]
+dev = ["dev", "check", "doc", "jax", "pyFFTW", "helpers", "dashboards"]
+doc = ["doc", "jax", "pyFFTW", "helpers"]
+check = ["check", "jax", "pyFFTW", "helpers"]
 
-[tool.pixi.feature.dev.dependencies]
+[tool.pixi.feature.doc.dependencies]
 pandoc = ">=3.5,<4"


### PR DESCRIPTION
Stacked PRs:
 * #178
 * #177
 * #173
 * #176
 * #171
 * #170
 * #169
 * #168
 * #167
 * #166
 * #165
 * #175
 * #164
 * #163
 * #162
 * #160
 * #159
 * __->__#158
 * #157


--- --- ---

### Split dev dependencies into check and doc and tweak CI


This way the separate github actions do have less packages to install and they run faster.
There is still a "dev" environment which combines every dependency.
In order to also support CI in stacked PRs the triggers are adjusted to trigger on any PR.
The names of the jobs are made more clear.
Tests now use a `test` and not a `build` action.
