### PR TITLE
Remove slow tests from pip CI run

### DIFF
--- a/.github/workflows/pip_test.yml
+++ b/.github/workflows/pip_test.yml
@@ -28,4 +28,4 @@ jobs:
         python -m pip install -e ".[check]"
     - name: Test with pytest
       run: |
-        python -m pytest --include-slow
+        python -m pytest


### PR DESCRIPTION
Stacked PRs:
 * #173
 * #171
 * #177
 * #179
 * #176
 * #170
 * #169
 * #168
 * #167
 * #166
 * #165
 * #164
 * #163
 * #162
 * __->__#160
 * #159


--- --- ---

### Remove slow tests from pip CI run


Before this change this is the slowest overall CI job. Since the full test suite is already run via pixi (which is faster with its setup, especially when cached) the pip CI job is only there for testing the more traditional way of installation and does not have to run every test.
