### PR TITLE
Refactor _unpacking.py into better named file

### DIFF
--- a/fftarray/_utils/uniform_value.py
+++ b/fftarray/_utils/uniform_value.py
@@ -1,22 +1,6 @@
-from typing import Tuple, Any, Union, TypeVar, Iterable, Generic
-from functools import reduce
-
+from typing import Any, TypeVar, Generic
 
 T = TypeVar("T")
-
-#------------
-# Helpers to reduce objects that should be same for all elements of a list
-#------------
-def reduce_equal(objects: Iterable[T], error_msg: str) -> T:
-    """
-        Reduce the Iterable to a single instance while checking the assumption that all objects are the same.
-    """
-    def join_equal(a, b):
-        if a == b:
-            return a
-        raise ValueError(error_msg)
-    return reduce(join_equal, objects)
-
 
 class UniformValue(Generic[T]):
     """
@@ -60,14 +44,4 @@ class UniformValue(Generic[T]):
 
         raise ValueError("Value has never been set.")
 
-
-def norm_param(val: Union[T, Iterable[T]], n: int, types) -> Tuple[T, ...]:
-    """
-       `val` has to be immutable.
-    """
-    if isinstance(val, types):
-        return (val,)*n
-
-    # TODO: Can we make this type check work?
-    return tuple(val) # type: ignore
 

--- a/fftarray/fft_array.py
+++ b/fftarray/fft_array.py
@@ -16,7 +16,7 @@ from .backends.numpy import NumpyBackend
 
 from ._utils.ufuncs import binary_ufuncs, unary_ufunc
 from ._utils.formatting import fft_dim_table, format_bytes
-from ._utils.unpacking import UniformValue, norm_param
+from ._utils.uniform_value import UniformValue
 from ._utils.indexing import (
     LocFFTArrayIndexer, check_missing_dim_names,
     tuple_indexers_from_dict_or_tuple, tuple_indexers_from_mapping,
@@ -28,6 +28,18 @@ if TYPE_CHECKING:
 
 EllipsisType = TypeVar('EllipsisType')
 Space = Literal["pos", "freq"]
+
+T = TypeVar("T")
+
+def norm_param(val: Union[T, Iterable[T]], n: int, types) -> Tuple[T, ...]:
+    """
+       `val` has to be immutable.
+    """
+    if isinstance(val, types):
+        return (val,)*n
+
+    # TODO: Can we make this type check work?
+    return tuple(val) # type: ignore
 
 class FFTArray:
     """A single class implementing FFTs."""


### PR DESCRIPTION
Stacked PRs:
 * #173
 * #171
 * #177
 * #179
 * #176
 * #170
 * #169
 * #168
 * #167
 * __->__#166
 * #165
 * #164
 * #163
 * #162


--- --- ---

### Refactor _unpacking.py into better named file


Move norm_param into fft_array.py since it is not really related.
While UniformValue cleanly fits into its own module.
