### PR TITLE
Remove implementation of __array__

### DIFF
--- a/examples/Gaussians.ipynb
+++ b/examples/Gaussians.ipynb
@@ -74,8 +74,8 @@
     "gauss_from_pos = gauss_pos(a = 1.2, x = x, sigma = 0.7)\n",
     "gauss_from_freq = gauss_freq(a = 1.2, f = f, sigma = 0.7)\n",
     "\n",
-    "np.testing.assert_array_almost_equal(gauss_from_pos, gauss_from_freq.into(space=\"pos\"))\n",
-    "np.testing.assert_array_almost_equal(gauss_from_freq, gauss_from_pos.into(space=\"freq\"))\n",
+    "np.testing.assert_array_almost_equal(gauss_from_pos.np_array(\"pos\"), gauss_from_freq.np_array(\"pos\"))\n",
+    "np.testing.assert_array_almost_equal(gauss_from_freq.np_array(\"freq\"), gauss_from_pos.np_array(\"freq\"))\n",
     "\n",
     "plt_fftarray(gauss_from_pos, data_name=\"Gauss (initialised with position)\")\n",
     "plt_fftarray(gauss_from_freq, data_name=\"Gauss (initialised with frequency)\")"
@@ -99,8 +99,8 @@
     "gauss_from_pos = shift_frequency(gauss_pos(a = 1.2, x = x, sigma = 0.7), {\"x\": 0.9})\n",
     "gauss_from_freq = gauss_freq(a = 1.2, f = f - 0.9, sigma = 0.7)\n",
     "\n",
-    "np.testing.assert_array_almost_equal(gauss_from_pos, gauss_from_freq.into(space=\"pos\"))\n",
-    "np.testing.assert_array_almost_equal(gauss_from_freq, gauss_from_pos.into(space=\"freq\"))\n",
+    "np.testing.assert_array_almost_equal(gauss_from_pos.np_array(\"pos\"), gauss_from_freq.np_array(\"pos\"))\n",
+    "np.testing.assert_array_almost_equal(gauss_from_freq.np_array(\"freq\"), gauss_from_pos.np_array(\"freq\"))\n",
     "\n",
     "plt_fftarray(gauss_from_pos, data_name=\"Gauss (freq. shifted via FFT)\")\n",
     "plt_fftarray(gauss_from_freq, data_name=\"Gauss (freq. shifted at init)\")"
@@ -123,8 +123,8 @@
     "gauss_from_pos = gauss_pos(a = 1.2, x = x - 0.9, sigma = 0.7)\n",
     "gauss_from_freq = shift_position(gauss_freq(a = 1.2, f = f, sigma = 0.7), {\"x\": 0.9})\n",
     "\n",
-    "np.testing.assert_array_almost_equal(gauss_from_pos, gauss_from_freq.into(space=\"pos\"))\n",
-    "np.testing.assert_array_almost_equal(gauss_from_freq, gauss_from_pos.into(space=\"freq\"))\n",
+    "np.testing.assert_array_almost_equal(gauss_from_pos.np_array(\"pos\"), gauss_from_freq.np_array(\"pos\"))\n",
+    "np.testing.assert_array_almost_equal(gauss_from_freq.np_array(\"freq\"), gauss_from_pos.np_array(\"freq\"))\n",
     "\n",
     "plt_fftarray(gauss_from_pos, data_name=\"Gauss (pos. shifted at init)\")\n",
     "plt_fftarray(gauss_from_freq, data_name=\"Gauss (pos. shifted via FFT)\")"

--- a/examples/helpers.py
+++ b/examples/helpers.py
@@ -43,7 +43,7 @@ def plt_fftarray(
             )
 
             # FFTArray values
-            values_in_space = np.array(arr.into(space=space))
+            values_in_space = arr.np_array(space=space)
             values_imag_part = values_in_space.imag
             values_real_part = values_in_space.real
 

--- a/fftarray/fft_array.py
+++ b/fftarray/fft_array.py
@@ -157,16 +157,6 @@ class FFTArray:
     def __array_ufunc__(self, ufunc, method, *inputs, **kwargs):
         return _array_ufunc(self, ufunc, method, inputs, kwargs)
 
-    # Support numpy array protocol.
-    # Many libraries use this to coerce special types to plain numpy array e.g.
-    # via np.array(fftarray)
-    def __array__(self, dtype=None, copy=None):
-        if copy is False:
-            raise ValueError("FFTArray is by design immutable and therefore does not allow direct access to the underlying array.")
-        # numpy < 2.0 does not support copy=None.
-        # As we anyway only allow copies at the moment, we can map `None` to `True`.
-        return np.array(self.values(space=self.space), dtype=dtype, copy=True)
-
     # Implement binary operations between FFTArray and also e.g. 1+wf and wf+1
     # This does intentionally not list all possible operators.
     __add__, __radd__ = binary_ufuncs(np.add)
@@ -655,7 +645,7 @@ class FFTArray:
             self._backend.array([fft_dim.d_pos for fft_dim in self._dims])
         )
 
-    def np_array(self: FFTArray, space: Space):
+    def np_array(self: FFTArray, space: Union[Space, Iterable[Space]], dtype = None):
         """..
 
         Returns
@@ -663,7 +653,9 @@ class FFTArray:
         NDArray
             The values of this FFTArray in the specified space as a bare numpy array.
         """
-        return np.array(self.into(backend=NumpyBackend(self.backend.precision), space=space))
+
+        values = self.into(backend=NumpyBackend(self.backend.precision)).values(space=space)
+        return np.array(values, dtype=dtype)
 
     def _check_consistency(self) -> None:
         """

--- a/fftarray/tests/test_fft_array.py
+++ b/fftarray/tests/test_fft_array.py
@@ -79,6 +79,9 @@ def test_comparison(backend_class, space) -> None:
     x = x_dim.fft_array(backend=backend_class(), space=space)
     x_sq = x**2
 
+    x = x.np_array(space=space)
+    x_sq = x_sq.np_array(space=space)
+
     # Eplicitly test the operators to check that the forwarding to array_ufunc is correct
     for a, b in [(0.5, x), (x, x_sq), (x, 0.5), (x, x_sq)]:
         np.testing.assert_array_equal(a < b, np.array(a) < np.array(b), strict=True)
@@ -184,8 +187,8 @@ def test_broadcasting(nulp: int = 1) -> None:
 
     x_ref = np.arange(0., 4.)
     y_ref = np.arange(0., 8.)
-    np.testing.assert_array_almost_equal_nulp(np.array(x_dim.fft_array(backend=NumpyBackend(), space="pos")), x_ref, nulp = 0)
-    np.testing.assert_array_almost_equal_nulp(np.array(y_dim.fft_array(backend=NumpyBackend(), space="pos")), y_ref, nulp = 0)
+    np.testing.assert_array_almost_equal_nulp(x_dim.fft_array(backend=NumpyBackend(), space="pos").np_array(space="pos"), x_ref, nulp = 0)
+    np.testing.assert_array_almost_equal_nulp(y_dim.fft_array(backend=NumpyBackend(), space="pos").np_array(space="pos"), y_ref, nulp = 0)
 
     x_ref_broadcast = x_ref.reshape(1,-1)
     y_ref_broadcast = y_ref.reshape(-1,1)

--- a/fftarray/tests/test_fft_dimension.py
+++ b/fftarray/tests/test_fft_dimension.py
@@ -69,14 +69,14 @@ def test_arrays(backend) -> None:
         n = n,
     )
 
-    pos_grid = np.array(fftdim.fft_array(backend=backend, space="pos"))
+    pos_grid = fftdim.fft_array(backend=backend, space="pos").np_array(space="pos")
     assert_scalars_almost_equal_nulp(fftdim.pos_min, np.min(pos_grid))
     assert_scalars_almost_equal_nulp(fftdim.pos_min, pos_grid[0])
     assert_scalars_almost_equal_nulp(fftdim.pos_max, np.max(pos_grid))
     assert_scalars_almost_equal_nulp(fftdim.pos_max, pos_grid[-1])
     assert_scalars_almost_equal_nulp(fftdim.pos_middle, pos_grid[int(n/2)])
 
-    freq_grid = np.array(fftdim.fft_array(backend=backend, space="freq"))
+    freq_grid = fftdim.fft_array(backend=backend, space="freq").np_array(space="freq")
     assert_scalars_almost_equal_nulp(fftdim.freq_min, np.min(freq_grid))
     assert_scalars_almost_equal_nulp(fftdim.freq_min, freq_grid[0])
     assert_scalars_almost_equal_nulp(fftdim.freq_max, np.max(freq_grid))

--- a/fftarray/xr_helpers.py
+++ b/fftarray/xr_helpers.py
@@ -1,4 +1,3 @@
-import numpy as np
 import xarray as xr
 
 from .fft_array import FFTArray
@@ -9,7 +8,7 @@ from .fft_array import FFTArray
 
 def as_xr_pos(arr: FFTArray) -> xr.DataArray:
     return xr.DataArray(
-        np.array(arr.into(space="pos")),
+        arr.np_array(space="pos"),
         coords = {dim.name: dim.np_array(space="pos") for dim in arr.dims},
         # TODO These in the attributes somehow crash where with a pickle error.
         # attrs = _xr_attribs(arr),
@@ -17,7 +16,7 @@ def as_xr_pos(arr: FFTArray) -> xr.DataArray:
 
 def as_xr_freq(arr: FFTArray) -> xr.DataArray:
     return xr.DataArray(
-        np.array(arr.into(space="freq")),
+        arr.np_array(space="freq"),
         coords = {dim.name: dim.np_array(space="freq") for dim in arr.dims},
         # attrs = _xr_attribs(arr),
     )
@@ -25,14 +24,14 @@ def as_xr_freq(arr: FFTArray) -> xr.DataArray:
 def as_xr_dataset(arr: FFTArray) -> xr.Dataset:
     return xr.Dataset({
             "pos": xr.DataArray(
-                np.array(arr.into(space="pos")),
+                arr.np_array(space="pos"),
                 coords = {
                     f"{dim.name}_pos": dim.np_array(space="pos")
                     for dim in arr.dims
                 }
             ),
             "freq":  xr.DataArray(
-                np.array(arr.into(space="freq")),
+                arr.np_array(space="freq"),
                 coords = {
                     f"{dim.name}_freq": dim.np_array(space="freq")
                     for dim in arr.dims


### PR DESCRIPTION
Stacked PRs:
 * #173
 * #171
 * #177
 * #179
 * #176
 * #170
 * #169
 * #168
 * __->__#167
 * #166
 * #165
 * #164
 * #163
 * #162


--- --- ---

### Remove implementation of __array__


This was deemed more in line with our philosophy to make the space of values extracted from the library explicit.
The np_array method gets an optional dtype argument like __array__.
Fixes wrong type annotation for space.

Co-authored-by: Christian Struckmann <56967696+cstruckmann@users.noreply.github.com>
Co-authored-by: Gabriel Müller <g.mueller@iqo.uni-hannover.de>
