### PR TITLE
Change name of FFTDimension to be of type str and not Hashable.

### DIFF
--- a/fftarray/_utils/indexing.py
+++ b/fftarray/_utils/indexing.py
@@ -1,6 +1,6 @@
 from typing import (
     Dict, List, Optional, Tuple, TypeVar, Union, Iterable,
-    Hashable, Literal, Literal, Generic, TYPE_CHECKING
+    Literal, Literal, Generic, TYPE_CHECKING
 )
 import warnings
 
@@ -60,7 +60,7 @@ class LocFFTArrayIndexer(Generic[T]):
 
         Parameters
         ----------
-        item : Union[ int, slice, EllipsisType, Tuple[Union[int, slice, EllipsisType],...], Mapping[Hashable, Union[int, slice]], ]
+        item : Union[ int, slice, EllipsisType, Tuple[Union[int, slice, EllipsisType],...], Mapping[str, Union[int, slice]], ]
             An indexer object with dimension lookup method either
             via position or name. When using positional lookup, the order
             of the dimensions in the FFTArray object is used (FFTArray.dims).
@@ -151,8 +151,8 @@ def parse_tuple_indexer_to_dims(
     return full_tuple_indexers
 
 def check_missing_dim_names(
-    indexer_names: Iterable[Hashable],
-    dim_names: Tuple[Hashable, ...],
+    indexer_names: Iterable[str],
+    dim_names: Tuple[str, ...],
     missing_dims: Literal["raise", "warn", "ignore"],
 ) -> None:
     """Check for indexers with a dimension name that does not appear in the FFTArray.

--- a/fftarray/fft_array.py
+++ b/fftarray/fft_array.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
 from collections import abc
 from typing import (
-    Mapping, Optional, Union, List, Any, Tuple, Dict, Hashable,
-    Literal, TypeVar, Iterable, Set, get_args
+    Mapping, Optional, Union, List, Any, Tuple, Dict,
+    Literal, TypeVar, Iterable, Set, get_args,
 )
 from copy import copy
 from numbers import Number
@@ -188,7 +188,7 @@ class FFTArray:
             item: Union[
                 int, slice, EllipsisType,
                 Tuple[Union[int, slice, EllipsisType],...],
-                Mapping[Hashable, Union[int, slice]],
+                Mapping[str, Union[int, slice]],
             ]
         ) -> FFTArray:
         """This method is called when indexing an FFTArray instance by integer index,
@@ -217,7 +217,7 @@ class FFTArray:
 
         Parameters
         ----------
-        item : Union[ int, slice, EllipsisType, Tuple[Union[int, slice, EllipsisType],...], Mapping[Hashable, Union[int, slice]], ]
+        item : Union[ int, slice, EllipsisType, Tuple[Union[int, slice, EllipsisType],...], Mapping[str, Union[int, slice]], ]
             An indexer object with either dimension lookup method either
             via position or name. When using positional lookup, the order
             of the dimensions in the FFTArray object is applied (FFTArray.dims).
@@ -242,7 +242,7 @@ class FFTArray:
         # Return full tuple of indexers as slice or int object
         tuple_indexers: Tuple[Union[int, slice], ...] = tuple_indexers_from_dict_or_tuple(
             indexers=item, # type: ignore
-            dim_names=tuple(dim.name for dim in self.dims) # type: ignore
+            dim_names=tuple(dim.name for dim in self.dims)
         )
 
         new_dims = []
@@ -339,7 +339,7 @@ class FFTArray:
         # Map indexers into full tuple of valid indexers, one entry per dimension
         tuple_indexers: Tuple[Union[int, slice], ...] = tuple_indexers_from_mapping(
             final_indexers, # type: ignore
-            dim_names=[dim.name for dim in self.dims], # type: ignore
+            dim_names=[dim.name for dim in self.dims],
         )
 
         return self.__getitem__(tuple_indexers)
@@ -395,7 +395,7 @@ class FFTArray:
         tuple_indexers_as_integer = []
         for dim, space in zip(self.dims, self.space):
             if dim.name in final_indexers:
-                index = final_indexers[dim.name] # type: ignore
+                index = final_indexers[dim.name]
                 try:
                     tuple_indexers_as_integer.append(
                         dim._index_from_coord(
@@ -432,12 +432,12 @@ class FFTArray:
         return self.__getitem__(tuple(tuple_indexers_as_integer))
 
     @property
-    def dims_dict(self) -> Dict[Hashable, FFTDimension]:
+    def dims_dict(self) -> Dict[str, FFTDimension]:
         # TODO Ordered Mapping?
         return {dim.name: dim for dim in self._dims}
 
     @property
-    def sizes(self) -> Dict[Hashable, int]:
+    def sizes(self) -> Dict[str, int]:
         # TODO Ordered Mapping?
         return {dim.name: dim.n for dim in self._dims}
 
@@ -574,7 +574,7 @@ class FFTArray:
     def backend(self) -> Backend:
         return self._backend
 
-    def transpose(self: FFTArray, *dims: Hashable) -> FFTArray:
+    def transpose(self: FFTArray, *dims: str) -> FFTArray:
         """
             Transpose with dimension names.
         """
@@ -670,7 +670,7 @@ class FFTArray:
         assert len(self._eager) == len(self._values.shape)
         assert len(self._factors_applied) == len(self._values.shape)
 
-        dim_names: Set[Hashable] = set()
+        dim_names: Set[str] = set()
         for n, dim in zip(self._values.shape, self._dims):
             assert dim.n == n, \
                 "Passed in inconsistent n from FFTDimension and values."
@@ -877,8 +877,8 @@ def _unpack_fft_arrays(
         This handles all "alignment" of input values.
         Align dimensions, unify them, unpack all operands to a simple list of values.
     """
-    dims: Dict[Hashable, UnpackedDimProperties] = {}
-    arrays_to_align: List[Tuple[List[Hashable], Any]] = []
+    dims: Dict[str, UnpackedDimProperties] = {}
+    arrays_to_align: List[Tuple[List[str], Any]] = []
     array_indices = []
     unpacked_values: List[Optional[Union[Number, Any]]] = [None]*len(values)
     backend: UniformValue[Backend] = UniformValue()

--- a/fftarray/fft_dimension.py
+++ b/fftarray/fft_dimension.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
-from typing import Optional, Union, Hashable, Literal
+from typing import Optional, Union, Literal
 from dataclasses import dataclass
 
 import numpy as np
@@ -159,7 +159,7 @@ class FFTDimension:
     _freq_min: float
     _d_pos: float
     _n: int
-    _name: Hashable
+    _name: str
     _dynamically_traced_coords: bool
 
     def __init__(
@@ -204,7 +204,7 @@ class FFTDimension:
         return self._n
 
     @property
-    def name(self: FFTDimension) -> Hashable:
+    def name(self: FFTDimension) -> str:
         """..
 
         Returns
@@ -327,7 +327,7 @@ class FFTDimension:
             assert False, "Unreachable"
 
         return FFTDimension(
-            name=self.name, # type: ignore
+            name=self.name,
             n=n,
             pos_min=pos_min,
             freq_min=freq_min,

--- a/fftarray/named_array.py
+++ b/fftarray/named_array.py
@@ -1,13 +1,13 @@
-from typing import Sequence, Tuple, Hashable, Any, List, Dict
+from typing import Sequence, Tuple, Any, List, Dict
 from dataclasses import dataclass
 
 #-------------------
 # TODO This is copied from abstraction but then quite significantly modified
 #-------------------
 def align_named_arrays(
-        arrays: Sequence[Tuple[Sequence[Hashable], Any]],
+        arrays: Sequence[Tuple[Sequence[str], Any]],
         backend
-    ) -> Tuple[Sequence[Hashable], List[Any]]:
+    ) -> Tuple[Sequence[str], List[Any]]:
     """
         The arrays may have longer shapes than there are named dims.
         Those are always kept as the last dims.
@@ -18,7 +18,7 @@ def align_named_arrays(
 
         Returns the new dim-names and the list of aligned arrays.
     """
-    target_shape: Dict[Hashable, int] = {}
+    target_shape: Dict[str, int] = {}
     for dims, arr in arrays:
         for i, dim in enumerate(dims):
             if dim in target_shape:
@@ -56,8 +56,8 @@ class FillDim:
         return hash(self.index)
 
 def get_axes_transpose(
-            old_dims: Sequence[Hashable],
-            new_dims: Sequence[Hashable]
+            old_dims: Sequence[str],
+            new_dims: Sequence[str]
         ) -> Tuple[int, ...]:
     assert len(old_dims) == len(new_dims)
     dim_index_lut = {dim: i for i, dim in enumerate(old_dims)}
@@ -67,8 +67,8 @@ def get_axes_transpose(
 def transpose_array(
         array: Any,
         backend,
-        old_dims: Sequence[Hashable],
-        new_dims: Sequence[Hashable]
+        old_dims: Sequence[str],
+        new_dims: Sequence[str]
     ) -> Any:
     """
         `old_dims` and `new_dims` must be a transpose of one another.

--- a/fftarray/tests/test_fft_array_indexing.py
+++ b/fftarray/tests/test_fft_array_indexing.py
@@ -1,6 +1,6 @@
 
 from functools import reduce
-from typing import Dict, Hashable, List, Literal, Mapping, Tuple, TypeVar, Union
+from typing import Dict, List, Literal, Mapping, Tuple, TypeVar, Union
 import pytest
 import numpy as np
 import jax
@@ -228,7 +228,7 @@ integer_indexers_test_samples = [
 def test_3d_fft_array_indexing_by_integer(
     space: Space,
     backend_class,
-    indexers: Mapping[Hashable, Union[int, slice]],
+    indexers: Mapping[str, Union[int, slice]],
 ) -> None:
 
     fft_array, xr_dataset = generate_test_fftarray_xrdataset(
@@ -327,7 +327,7 @@ label_indexers_test_samples = [
 def test_3d_fft_array_label_indexing(
     space: Space,
     backend_class,
-    indexers: Mapping[Hashable, Union[int, slice]],
+    indexers: Mapping[str, Union[int, slice]],
     method: Literal["nearest", "pad", "ffill", "backfill", "bfill", None],
 ) -> None:
 
@@ -366,7 +366,7 @@ def test_3d_fft_array_label_indexing(
 def test_3d_fft_array_indexing(
     space: Space,
     index_by: Literal["label", "integer"],
-    indexers: Mapping[Hashable, Union[int, slice]],
+    indexers: Mapping[str, Union[int, slice]],
 ) -> None:
 
     backend = JaxBackend()
@@ -448,7 +448,7 @@ space_combinations = [
 def test_fftarray_state_management(
     space_combination: Dict[str, Space],
     backend_class,
-    indexers: Mapping[Hashable, Union[int, slice]],
+    indexers: Mapping[str, Union[int, slice]],
 ) -> None:
     """
     Tests if the indexed FFTArray has the correct internal properties,

--- a/fftarray/tools.py
+++ b/fftarray/tools.py
@@ -1,4 +1,4 @@
-from typing import Dict, Hashable
+from typing import Dict
 
 import numpy as np
 
@@ -6,7 +6,7 @@ from fftarray import FFTArray
 import fftarray as fa
 
 # TODO: change names of FFTArray argument here
-def shift_frequency(wf: FFTArray, offsets: Dict[Hashable, float]) -> FFTArray:
+def shift_frequency(wf: FFTArray, offsets: Dict[str, float]) -> FFTArray:
     """Shift the wavefunction in frequency space:
     :math:`k_{x,y,z} \mapsto k_{x,y,z} - \Delta k_{x,y,z}`.
     The wavefunction is transformed according to:
@@ -44,7 +44,7 @@ def shift_frequency(wf: FFTArray, offsets: Dict[Hashable, float]) -> FFTArray:
         phase_shift *= np.exp(1.j * 2.*np.pi * offset * x)
     return wf.into(space="pos") * phase_shift
 
-def shift_position(wf: FFTArray, offsets: Dict[Hashable, float]) -> FFTArray:
+def shift_position(wf: FFTArray, offsets: Dict[str, float]) -> FFTArray:
     """Shift the wavefunction in position space:
     :math:`x \mapsto x - \Delta x`. :math:`y` and :math:`z` analogously.
     The wavefunction is transformed according to:


### PR DESCRIPTION
Stacked PRs:
 * #173
 * #171
 * #177
 * #179
 * __->__#176


--- --- ---

### Change name of FFTDimension to be of type str and not Hashable.


We decided there are no good enough use-cases and this is easier in implementation (easily check isinstance(name, str) when allowing a single and multiple names) and the type annotations are easier to read for beginners.

Co-authored by Gabriel Müller <g.mueller@iqo.uni-hannover.de>
