### PR TITLE
Add array method for creating a FFTArray from values to top namespace.

### DIFF
--- a/fftarray/__init__.py
+++ b/fftarray/__init__.py
@@ -37,7 +37,7 @@ from .space import Space
 from .fft_dimension import FFTDimension, dim
 from .fft_array import FFTArray
 
-from .creation_functions import array_from_dim
+from .creation_functions import array, array_from_dim
 
 from .tools import shift_frequency, shift_position
 

--- a/fftarray/_utils/helpers.py
+++ b/fftarray/_utils/helpers.py
@@ -1,0 +1,13 @@
+from typing import TypeVar, Union, Iterable, Tuple
+
+T = TypeVar("T")
+
+def norm_param(val: Union[T, Iterable[T]], n: int, types) -> Tuple[T, ...]:
+    """
+       `val` has to be immutable.
+    """
+    if isinstance(val, types):
+        return (val,)*n
+
+    # TODO: Can we make this type check work?
+    return tuple(val) # type: ignore

--- a/fftarray/creation_functions.py
+++ b/fftarray/creation_functions.py
@@ -1,9 +1,82 @@
-from typing import Optional
+from typing import Optional, Union, Iterable, Tuple, get_args
 
 from .backends.backend import Backend
 from .fft_dimension import FFTDimension
-from .fft_array import FFTArray, get_default_backend, get_default_eager
+from .fft_array import FFTArray
+from ._utils.defaults import get_default_backend, get_default_eager
 from .space import Space
+from ._utils.helpers import norm_param
+
+def array(
+        values,
+        dims: Union[FFTDimension, Iterable[FFTDimension]],
+        space: Union[Space, Iterable[Space]],
+        *,
+        backend: Optional[Backend] = None,
+        eager: Optional[Union[bool, Iterable[bool]]] = None,
+        factors_applied: Union[bool, Iterable[bool]] = True,
+    ) -> FFTArray:
+    """
+        Construct a new instance of FFTArray from raw values.
+
+        Parameters
+        ----------
+        values :
+            The values to initialize the `FFTArray` with.
+            They are converted and copied into an array of the backend.
+        dims : Iterable[FFTDimension]
+            The FFTDimensions for each dimension of the passed in values.
+        space: Union[Space, Iterable[Space]]
+            Specify the space of the coordinates and in which space the returned FFTArray is intialized.
+        backend: Optional[Backend]
+            The backend to use for the returned FFTArray.  `None` uses default `NumpyBackend("default")` which can be globally changed.
+            The values are transformed into the appropiate type defined by the backend.
+        eager: Union[bool, Iterable[bool]]
+            The eager-mode to use for the returned FFTArray.  `None` uses default `False` which can be globally changed.
+        factors_applied: Union[bool, Iterable[bool]]
+            Whether the fft-factors are applied are already applied for the various dimensions.
+            For external values this is usually `True` since `False` assumes the internal (and unstable)
+            factors-format.
+
+        Returns
+        -------
+        FFTArray
+            The grid coordinates of the chosen space packed into an FFTArray with self as only dimension.
+
+        See Also
+        --------
+        set_default_backend, get_default_backend
+        set_default_eager, get_default_eager
+        fft_array
+    """
+
+    if backend is None:
+        backend = get_default_backend()
+
+    if eager is None:
+        eager = get_default_eager()
+
+    if isinstance(dims, FFTDimension):
+        dims_tuple: Tuple[FFTDimension, ...] = (dims,)
+    else:
+        dims_tuple = tuple(dims)
+
+    n_dims = len(dims_tuple)
+    inner_values = backend.array(values)
+    spaces_normalized: Tuple[Space, ...] = norm_param(space, n_dims, str)
+    for sub_space in spaces_normalized:
+        assert sub_space in get_args(Space)
+
+    arr = FFTArray(
+        dims=dims_tuple,
+        values=inner_values,
+        space=spaces_normalized,
+        eager=norm_param(eager, n_dims, bool),
+        factors_applied=norm_param(factors_applied, n_dims, bool),
+        backend=backend,
+    )
+    arr._check_consistency()
+    return arr
 
 def array_from_dim(
         dim: FFTDimension,
@@ -49,9 +122,9 @@ def array_from_dim(
 
     return FFTArray(
         values=values,
-        dims=[dim],
-        eager=eager,
-        factors_applied=True,
-        space=space,
+        dims=(dim,),
+        eager=(eager,),
+        factors_applied=(True,),
+        space=(space,),
         backend=backend,
     )

--- a/fftarray/tests/test_fft_array.py
+++ b/fftarray/tests/test_fft_array.py
@@ -8,6 +8,7 @@ import jax.numpy as jnp
 
 import fftarray as fa
 from fftarray.fft_array import FFTArray, Space
+from fftarray.creation_functions import array
 from fftarray.backends.jax import JaxBackend
 from fftarray.backends.numpy import NumpyBackend
 from fftarray.backends.backend import Backend, PrecisionSpec, InvalidPrecisionError
@@ -22,7 +23,7 @@ precisions: List[PrecisionSpec] = ["fp32", "fp64", "default"]
 spaces: List[Space] = ["pos", "freq"]
 
 # Currently only tests the values type
-def test_fft_array_constructor():
+def test_fft_array_constructor() -> None:
     """Tests whether the type checking of the FFTArray input values works.
     An FFTArray can only be initialized if the values array type is compatible
     with the provided Backend.
@@ -32,36 +33,19 @@ def test_fft_array_constructor():
     np_arr = np.array(values)
     jnp_arr = jnp.array(values)
 
-    failing_sets = [
-        (values, [NumpyBackend(), JaxBackend()]),
-        (np_arr, [JaxBackend()]),
-        (jnp_arr, [NumpyBackend()]),
-    ]
-    for arr, backends in failing_sets:
-        for backend in backends:
-            with pytest.raises(ValueError):
-                _ = FFTArray(
-                    values=arr,
-                    dims=[dim],
-                    space="pos",
-                    eager=False,
-                    factors_applied=False,
-                    backend=backend,
-                )
-
-    working_sets = [
-        (np_arr, NumpyBackend()),
-        (jnp_arr, JaxBackend()),
-    ]
-    for arr, backend in working_sets:
-            _ = FFTArray(
-                values=arr,
+    backends = [NumpyBackend(), JaxBackend()]
+    backend_array_class = [np.ndarray, jax.Array]
+    for val_arr in [values, np_arr, jnp_arr]:
+        for backend, array_class in zip(backends, backend_array_class):
+            arr = array(
+                values=val_arr,
                 dims=[dim],
                 space="pos",
                 eager=False,
                 factors_applied=False,
                 backend=backend,
             )
+            assert isinstance(arr.values("pos"), array_class)
 
 
 @pytest.mark.parametrize("backend_class", backends)
@@ -136,21 +120,21 @@ def test_dtype(backend, precision, override, eager: bool) -> None:
 
     int_arr = FFTArray(
         values=backend_init.array([1,2,3,4]),
-        dims=[x_dim],
-        space="pos",
-        eager=eager,
+        dims=(x_dim,),
+        space=("pos",),
+        eager=(eager,),
         backend=backend_init,
-        factors_applied=True,
+        factors_applied=(True,),
     )
     assert int_arr.values(space="pos").dtype == int_arr.into(backend=backend_override).values(space="pos").dtype
 
     bool_arr = FFTArray(
         values=backend_init.array([False, True, False, False]),
-        dims=[x_dim],
-        space="pos",
-        eager=eager,
+        dims=(x_dim,),
+        space=("pos",),
+        eager=(eager,),
         backend=backend_init,
-        factors_applied=True,
+        factors_applied=(True,),
     )
     assert bool_arr.values(space="pos").dtype == bool_arr.into(backend=backend_override).values(space="pos").dtype
 
@@ -244,16 +228,22 @@ def test_defaults_context() -> None:
 
 
 def check_defaults(dim, backend: Backend, eager: bool) -> None:
-    arr = fa.array_from_dim(dim=dim, space="pos")
+    values = 0.1*backend.numpy_ufuncs.arange(4, dtype=backend.real_type)
+    arr_from_dim = fa.array_from_dim(dim=dim, space="pos")
+    arr_direct = fa.array(dims=dim, space="pos", values=values)
     manual_arr = FFTArray(
-        values=0.1*backend.numpy_ufuncs.arange(4, dtype=backend.real_type),
-        dims=[dim],
-        space="pos",
+        values=values,
+        dims=(dim,),
+        space=("pos",),
+        eager=(eager,),
+        backend=backend,
+        factors_applied=(True,),
     )
-    assert (manual_arr==arr).values(space="pos").all()
-    assert fa.get_default_backend() == backend
-    assert arr.eager == (eager,)
-    assert arr.backend == backend
+    for arr in [arr_from_dim, arr_direct]:
+        assert (manual_arr==arr).values(space="pos").all()
+        assert fa.get_default_backend() == backend
+        assert arr.eager == (eager,)
+        assert arr.backend == backend
 
 def test_bool() -> None:
     xdim = fa.dim("x", n=4, d_pos=0.1, pos_min=-0.2, freq_min=-2.1)
@@ -269,7 +259,7 @@ def draw_hypothesis_fft_array_values(draw, st_type, shape):
     return draw(st.lists(st_type, min_size=shape[0], max_size=shape[0]))
 
 @st.composite
-def fftarray_strategy(draw):
+def fftarray_strategy(draw) -> FFTArray:
     """Initializes an FFTArray using hypothesis."""
     ndims = draw(st.integers(min_value=1, max_value=4))
     value = st.one_of([
@@ -296,7 +286,7 @@ def fftarray_strategy(draw):
     note(fftarr_values.dtype)
     note(fftarr_values)
 
-    return FFTArray(
+    return fa.array(
         values=fftarr_values,
         dims=dims,
         space=init_space,


### PR DESCRIPTION
Stacked PRs:
 * #173
 * #171
 * __->__#177


--- --- ---

### Add array method for creating a FFTArray from values to top namespace.


All input validation and comfort-functionality (including default backend and eager-mode) are moved into this method.
The constructor does no input sanitation and checkiong anymore to allow less overhead for internal functions.

Co-authored by Gabriel Müller <g.mueller@iqo.uni-hannover.de>
