### PR TITLE
Always use correct dtype and xp in shift functions

### DIFF
--- a/examples/Gaussians.ipynb
+++ b/examples/Gaussians.ipynb
@@ -98,7 +98,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "gauss_from_pos = fa.shift_frequency(gauss_pos(a = 1.2, x = x, sigma = 0.7), {\"x\": 0.9})\n",
+    "gauss_from_pos = fa.shift_freq(gauss_pos(a = 1.2, x = x, sigma = 0.7), {\"x\": 0.9})\n",
     "gauss_from_freq = gauss_freq(a = 1.2, f = f - 0.9, sigma = 0.7)\n",
     "\n",
     "np.testing.assert_array_almost_equal(gauss_from_pos.np_array(\"pos\"), gauss_from_freq.np_array(\"pos\"))\n",
@@ -123,7 +123,7 @@
    "outputs": [],
    "source": [
     "gauss_from_pos = gauss_pos(a = 1.2, x = x - 0.9, sigma = 0.7)\n",
-    "gauss_from_freq = fa.shift_position(gauss_freq(a = 1.2, f = f, sigma = 0.7), {\"x\": 0.9})\n",
+    "gauss_from_freq = fa.shift_pos(gauss_freq(a = 1.2, f = f, sigma = 0.7), {\"x\": 0.9})\n",
     "\n",
     "np.testing.assert_array_almost_equal(gauss_from_pos.np_array(\"pos\"), gauss_from_freq.np_array(\"pos\"))\n",
     "np.testing.assert_array_almost_equal(gauss_from_freq.np_array(\"freq\"), gauss_from_pos.np_array(\"freq\"))\n",

--- a/fftarray/__init__.py
+++ b/fftarray/__init__.py
@@ -60,8 +60,8 @@ from .creation_functions import (
 )
 
 from .tools import (
-    shift_frequency as shift_frequency,
-    shift_position as shift_position,
+    shift_freq as shift_freq,
+    shift_pos as shift_pos,
 )
 
 from .jax_pytrees import jax_register_pytree_nodes as jax_register_pytree_nodes

--- a/fftarray/tests/helpers.py
+++ b/fftarray/tests/helpers.py
@@ -1,3 +1,5 @@
+from typing import Union, Tuple
+
 import numpy as np
 import array_api_strict
 import array_api_compat
@@ -14,3 +16,14 @@ try:
     fa.jax_register_pytree_nodes()
 except ImportError:
     pass
+
+
+def get_other_space(space: Union[fa.Space, Tuple[fa.Space, ...]]):
+    """Returns the other space. If input space is "pos", "freq" is returned and
+    vice versa. If space is a `Tuple[Space]`, a tuple is returned.
+    """
+    if isinstance(space, str):
+        if space == "pos":
+            return "freq"
+        return "pos"
+    return tuple(get_other_space(s) for s in space)

--- a/fftarray/tests/test_fft_array.py
+++ b/fftarray/tests/test_fft_array.py
@@ -10,7 +10,7 @@ import jax.numpy as jnp
 import fftarray as fa
 from fftarray.fft_array import FFTArray, Space
 
-from fftarray.tests.helpers import XPS
+from fftarray.tests.helpers import XPS, get_other_space
 from fftarray._utils.defaults import DEFAULT_DTYPE
 
 PrecisionSpec = Literal["float32", "float64"]
@@ -514,16 +514,6 @@ def assert_dual_operand_fun_equivalence(arr: FFTArray, precise: bool, log):
         assert_equal_op(arr, values, (lambda x: x**xp.abs(x), lambda x: x**fa.abs(x)), precise, True, log)
     else:
         assert_equal_op(arr, values, lambda x: x**x, precise, True, log)
-
-def get_other_space(space: Union[Space, Tuple[Space, ...]]):
-    """Returns the other space. If input space is "pos", "freq" is returned and
-    vice versa. If space is a `Tuple[Space]`, a tuple is returned.
-    """
-    if isinstance(space, str):
-        if space == "pos":
-            return "freq"
-        return "pos"
-    return tuple(get_other_space(s) for s in space)
 
 def assert_fftarray_eager_factors_applied(arr: FFTArray, log):
     """Tests whether the factors are only applied when necessary and whether

--- a/tests/unit/test_tools.py
+++ b/tests/unit/test_tools.py
@@ -1,0 +1,82 @@
+from typing import get_args
+
+import pytest
+import numpy as np
+
+import fftarray as fa
+
+from fftarray.tests.helpers import XPS, get_other_space
+from fftarray.transform_application import complex_type
+
+@pytest.mark.parametrize("xp", XPS)
+@pytest.mark.parametrize("eager", [True, False])
+@pytest.mark.parametrize("space", get_args(fa.Space))
+@pytest.mark.parametrize("init_dtype_name, atol", [
+    pytest.param("float32", 1e-4),
+    pytest.param("float64", 1e-14),
+    pytest.param("complex64", 1e-4),
+    pytest.param("complex128", 1e-14),
+])
+def test_shift(
+        xp,
+        eager: bool,
+        space: fa.Space,
+        init_dtype_name: str,
+        atol: float,
+    ) -> None:
+
+    init_dtype = getattr(xp, init_dtype_name)
+    other_space= get_other_space(space)
+    # It is important to place both spaces symmetrically around zero to prevent aliasing of the test function in
+    # both spaces.
+    dim = fa.dim_from_constraints(name="x", n=128, d_pos=0.01, pos_middle=0., freq_middle=0.)
+    arr = fa.array_from_dim(
+        dim=dim,
+        space=space,
+        xp=xp,
+        dtype=init_dtype,
+        eager=eager,
+    )
+
+    # Use a frequency which fits exactly into the domain to allow periodic shifts
+    test_frequency = 5*2*np.pi*getattr(dim, f"d_{other_space}")
+    orig = fa.sin(test_frequency*arr)
+    shift_amount = 8.1*getattr(dim, f"d_{space}")
+
+    ref_shifted = fa.sin(test_frequency*(arr-shift_amount)).astype("complex")
+
+    shift_fun = getattr(fa, f"shift_{space}")
+    fft_shifted = shift_fun(orig, {"x": shift_amount})
+
+    assert fft_shifted.eager == orig.eager
+    assert fft_shifted.dtype == complex_type(xp, init_dtype)
+    assert fft_shifted.xp == orig.xp
+    assert fft_shifted.dims == orig.dims
+
+    np.testing.assert_allclose(
+        np.array(ref_shifted.values(space=space)),
+        np.array(fft_shifted.values(space=space)),
+        atol=atol,
+    )
+
+@pytest.mark.parametrize("xp", XPS)
+@pytest.mark.parametrize("init_dtype_name", ["bool", "int64", "uint64"])
+@pytest.mark.parametrize("space", get_args(fa.Space))
+def test_shift_int(
+        xp,
+        init_dtype_name: str,
+        space: fa.Space,
+    ) -> None:
+    """
+        Simply tests that the functions properly raise a ``ValueError``.
+    """
+    dim = fa.dim(name="x", n=4, d_pos=0.1, pos_min=0., freq_min=0.)
+    arr = fa.array(
+        xp.asarray([0, 1, 2, 4], dtype=getattr(xp, init_dtype_name)),
+        dims=[dim],
+        space=space,
+    )
+
+    shift_fun = getattr(fa, f"shift_{space}")
+    with pytest.raises(ValueError):
+        shift_fun(arr, {"x": 0.1})


### PR DESCRIPTION
Stacked PRs:
 * #203
 * #202
 * #200
 * #199
 * __->__#198


--- --- ---

### Always use correct dtype and xp in shift functions


Rename shift functions to `shift_pos` and `shift_freq` to be consistent with the other names.
Move `get_other_space` to test helpers
Add unit tests for shift functions

Co-authored-by: Gabriel Müller 51076825+gabmueller@users.noreply.github.com
