### PR TITLE
Update creation functions to new agreed design.

### DIFF
--- a/examples/Gaussians.ipynb
+++ b/examples/Gaussians.ipynb
@@ -51,8 +51,8 @@
     "    )\n",
     "\n",
     "\n",
-    "x = fa.array_from_dim(dim, \"pos\")\n",
-    "f = fa.array_from_dim(dim, \"freq\")\n",
+    "x = fa.coords_from_dim(dim, \"pos\")\n",
+    "f = fa.coords_from_dim(dim, \"freq\")\n",
     "\n",
     "plt_fftarray(x, data_name=\"FFTArray (identity in pos space)\")\n",
     "plt_fftarray(f, data_name=\"FFTArray (identity in freq space)\")"
@@ -156,7 +156,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.13.0"
+   "version": "3.13.1"
   },
   "orig_nbformat": 4
  },

--- a/examples/indexing.md
+++ b/examples/indexing.md
@@ -24,9 +24,9 @@ y_dim = fa.dim(name="y", n=8, d_pos=0.4, pos_min=0, freq_min=0)
 z_dim = fa.dim(name="z", n=8, d_pos=0.4, pos_min=0, freq_min=0)
 
 fft_arr = (
-    fa.array_from_dim(dim=x_dim, space="pos") +
-    fa.array_from_dim(dim=y_dim, space="pos") +
-    fa.array_from_dim(dim=z_dim, space="pos")
+    fa.coords_from_dim(dim=x_dim, space="pos") +
+    fa.coords_from_dim(dim=y_dim, space="pos") +
+    fa.coords_from_dim(dim=z_dim, space="pos")
 )
 ```
 ### Indexing by Integer

--- a/examples/multi_dimensional.ipynb
+++ b/examples/multi_dimensional.ipynb
@@ -59,8 +59,8 @@
     "        n=64,\n",
     "    )\n",
     "\n",
-    "x_dim_fftarray = fa.array_from_dim(x_dim, \"pos\")\n",
-    "y_dim_fftarray = fa.array_from_dim(y_dim, \"pos\")\n",
+    "x_dim_fftarray = fa.coords_from_dim(x_dim, \"pos\")\n",
+    "y_dim_fftarray = fa.coords_from_dim(y_dim, \"pos\")\n",
     "\n",
     "plt_fftarray(x_dim_fftarray, data_name=\"FFTArray with x_dim\")\n",
     "plt_fftarray(y_dim_fftarray, data_name=\"FFTArray with y_dim\")"
@@ -111,7 +111,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "base",
+   "display_name": "dev",
    "language": "python",
    "name": "python3"
   },
@@ -125,14 +125,9 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.13"
+   "version": "3.13.1"
   },
-  "orig_nbformat": 4,
-  "vscode": {
-   "interpreter": {
-    "hash": "77b60de724cd56e5333334a06ed3a5e18b3026c8349f95c7badc7f1caa70835a"
-   }
-  }
+  "orig_nbformat": 4
  },
  "nbformat": 4,
  "nbformat_minor": 2

--- a/fftarray/__init__.py
+++ b/fftarray/__init__.py
@@ -54,8 +54,8 @@ from .fft_array import (
 
 from .creation_functions import (
    array as array,
-   array_from_dim as array_from_dim,
-   coords_array as coords_array,
+   coords_from_dim as coords_from_dim,
+   coords_from_arr as coords_from_arr,
    full as full,
 )
 

--- a/fftarray/fft_array.py
+++ b/fftarray/fft_array.py
@@ -424,8 +424,8 @@ class FFTArray:
 
             Example usage:
             arr_2d = (
-                array_from_dim(x_dim, "pos")
-                + array_from_dim(y_dim, "pos")
+                coords_from_dim(x_dim, "pos")
+                + coords_from_dim(y_dim, "pos")
             )
             Four ways of retrieving an FFTArray object
             with index 3 along x and first 5 values along y:

--- a/fftarray/tests/helpers.py
+++ b/fftarray/tests/helpers.py
@@ -3,6 +3,7 @@ from typing import Union, Tuple
 import numpy as np
 import array_api_strict
 import array_api_compat
+import pytest
 
 import fftarray as fa
 
@@ -17,6 +18,10 @@ try:
 except ImportError:
     pass
 
+# This is helpful for tests where we need an xp which is not the currently tested one.
+XPS_ROTATED_PAIRS = [
+    pytest.param(xp1, xp2) for xp1, xp2 in zip(XPS, [*XPS[1:],XPS[0]], strict=True)
+]
 
 def get_other_space(space: Union[fa.Space, Tuple[fa.Space, ...]]):
     """Returns the other space. If input space is "pos", "freq" is returned and

--- a/fftarray/tests/test_fft_array.py
+++ b/fftarray/tests/test_fft_array.py
@@ -32,7 +32,7 @@ def test_comparison(xp, space) -> None:
         pos_min=0.5,
         freq_min=0.,
     )
-    x = fa.array_from_dim(dim=x_dim, xp=xp, space=space)
+    x = fa.coords_from_dim(dim=x_dim, xp=xp, space=space)
     x_sq = x**2
 
     x = x.np_array(space=space)
@@ -62,8 +62,7 @@ def get_complex_name(
 @pytest.mark.parametrize("xp", XPS)
 @pytest.mark.parametrize("init", ("float32", "float64"))
 @pytest.mark.parametrize("override", (None, "float32", "float64"))
-@pytest.mark.parametrize("eager", [False, True])
-def test_dtype(xp, init, override, eager: bool) -> None:
+def test_dtype(xp, init, override) -> None:
     init_dtype_real = getattr(xp, init)
     # TODO: This does not work in numpy < 2.0
     init_dtype_complex = getattr(xp, get_complex_name(init))
@@ -80,27 +79,27 @@ def test_dtype(xp, init, override, eager: bool) -> None:
     )
 
     if override is None:
-        assert fa.array_from_dim(dim=x_dim, space="pos", dtype=init_dtype_real, xp=xp).values(space="pos").dtype == init_dtype_real
+        assert fa.coords_from_dim(dim=x_dim, space="pos", dtype=init_dtype_real, xp=xp).values(space="pos").dtype == init_dtype_real
     else:
-        assert fa.array_from_dim(dim=x_dim, dtype=override_dtype_real, xp=xp, space="pos", eager=eager).values(space="pos").dtype == override_dtype_real
-        assert fa.array_from_dim(dim=x_dim, dtype=init_dtype_real, xp=xp, space="pos", eager=eager).astype(dtype=override_dtype_real).values(space="pos").dtype == override_dtype_real
+        assert fa.coords_from_dim(dim=x_dim, dtype=override_dtype_real, xp=xp, space="pos").values(space="pos").dtype == override_dtype_real
+        assert fa.coords_from_dim(dim=x_dim, dtype=init_dtype_real, xp=xp, space="pos").astype(dtype=override_dtype_real).values(space="pos").dtype == override_dtype_real
 
 
     if override is None:
-        assert fa.array_from_dim(dim=x_dim, dtype=init_dtype_real, xp=xp, space="freq", eager=eager).values(space="freq").dtype == init_dtype_real
+        assert fa.coords_from_dim(dim=x_dim, dtype=init_dtype_real, xp=xp, space="freq").values(space="freq").dtype == init_dtype_real
     else:
-        assert fa.array_from_dim(dim=x_dim, dtype=override_dtype_real, xp=xp, space="freq", eager=eager).values(space="freq").dtype == override_dtype_real
-        assert fa.array_from_dim(dim=x_dim, dtype=init_dtype_real, xp=xp, space="freq", eager=eager).astype(dtype=override_dtype_real).values(space="freq").dtype == override_dtype_real
+        assert fa.coords_from_dim(dim=x_dim, dtype=override_dtype_real, xp=xp, space="freq").values(space="freq").dtype == override_dtype_real
+        assert fa.coords_from_dim(dim=x_dim, dtype=init_dtype_real, xp=xp, space="freq").astype(dtype=override_dtype_real).values(space="freq").dtype == override_dtype_real
 
-    assert fa.array_from_dim(dim=x_dim, dtype=init_dtype_real, xp=xp, space="pos", eager=eager).into(space="freq").values(space="freq").dtype == init_dtype_complex
-    assert fa.array_from_dim(dim=x_dim, dtype=init_dtype_real, xp=xp, space="freq", eager=eager).into(space="pos").values(space="pos").dtype == init_dtype_complex
+    assert fa.coords_from_dim(dim=x_dim, dtype=init_dtype_real, xp=xp, space="pos").into(space="freq").values(space="freq").dtype == init_dtype_complex
+    assert fa.coords_from_dim(dim=x_dim, dtype=init_dtype_real, xp=xp, space="freq").into(space="pos").values(space="pos").dtype == init_dtype_complex
 
-    assert fa.abs(fa.array_from_dim(dim=x_dim, dtype=init_dtype_real, xp=xp, space="pos", eager=eager).into(space="freq")).values(space="freq").dtype == init_dtype_real # type: ignore
-    assert fa.abs(fa.array_from_dim(dim=x_dim, dtype=init_dtype_real, xp=xp, space="freq", eager=eager).into(space="pos")).values(space="pos").dtype == init_dtype_real # type: ignore
+    assert fa.abs(fa.coords_from_dim(dim=x_dim, dtype=init_dtype_real, xp=xp, space="pos").into(space="freq")).values(space="freq").dtype == init_dtype_real # type: ignore
+    assert fa.abs(fa.coords_from_dim(dim=x_dim, dtype=init_dtype_real, xp=xp, space="freq").into(space="pos")).values(space="pos").dtype == init_dtype_real # type: ignore
 
     if override is not None:
-        assert fa.array_from_dim(dim=x_dim, dtype=init_dtype_real, xp=xp, space="pos", eager=eager).astype(dtype=override_dtype_real).into(space="freq").values(space="freq").dtype == override_dtype_complex
-        assert fa.array_from_dim(dim=x_dim, dtype=init_dtype_real, xp=xp, space="freq", eager=eager).astype(dtype=override_dtype_real).into(space="pos").values(space="pos").dtype == override_dtype_complex
+        assert fa.coords_from_dim(dim=x_dim, dtype=init_dtype_real, xp=xp, space="pos").astype(dtype=override_dtype_real).into(space="freq").values(space="freq").dtype == override_dtype_complex
+        assert fa.coords_from_dim(dim=x_dim, dtype=init_dtype_real, xp=xp, space="freq").astype(dtype=override_dtype_real).into(space="pos").values(space="pos").dtype == override_dtype_complex
 
 
 @pytest.mark.parametrize("xp", XPS)
@@ -113,10 +112,10 @@ def test_backend_override(xp, xp_override) -> None:
         freq_min=0.,
     )
 
-    assert type(fa.array_from_dim(dim=x_dim, xp=xp, space="pos").asxp(xp=xp_override).values(space="pos")) is type(fa.array_from_dim(dim=x_dim, xp=xp_override, space="pos").values(space="pos"))
-    assert type(fa.array_from_dim(dim=x_dim, xp=xp, space="freq").asxp(xp=xp_override).values(space="freq")) is type(fa.array_from_dim(dim=x_dim, xp=xp_override, space="freq").values(space="freq"))
-    assert type(fa.array_from_dim(dim=x_dim, xp=xp, space="pos").asxp(xp=xp_override).into(space="freq").values(space="freq")) is type(fa.array_from_dim(dim=x_dim, xp=xp_override, space="freq").values(space="freq"))
-    assert type(fa.array_from_dim(dim=x_dim, xp=xp, space="freq").asxp(xp=xp_override).into(space="pos").values(space="pos")) is type(fa.array_from_dim(dim=x_dim, xp=xp_override, space="pos").values(space="pos"))
+    assert type(fa.coords_from_dim(dim=x_dim, xp=xp, space="pos").asxp(xp=xp_override).values(space="pos")) is type(fa.coords_from_dim(dim=x_dim, xp=xp_override, space="pos").values(space="pos"))
+    assert type(fa.coords_from_dim(dim=x_dim, xp=xp, space="freq").asxp(xp=xp_override).values(space="freq")) is type(fa.coords_from_dim(dim=x_dim, xp=xp_override, space="freq").values(space="freq"))
+    assert type(fa.coords_from_dim(dim=x_dim, xp=xp, space="pos").asxp(xp=xp_override).into(space="freq").values(space="freq")) is type(fa.coords_from_dim(dim=x_dim, xp=xp_override, space="freq").values(space="freq"))
+    assert type(fa.coords_from_dim(dim=x_dim, xp=xp, space="freq").asxp(xp=xp_override).into(space="pos").values(space="pos")) is type(fa.coords_from_dim(dim=x_dim, xp=xp_override, space="pos").values(space="pos"))
 
 
 def test_broadcasting() -> None:
@@ -125,13 +124,13 @@ def test_broadcasting() -> None:
 
     x_ref = np.arange(0., 4.)
     y_ref = np.arange(0., 8.)
-    np.testing.assert_array_almost_equal_nulp(fa.array_from_dim(dim=x_dim, xp=np, space="pos").np_array(space="pos"), x_ref, nulp = 0)
-    np.testing.assert_array_almost_equal_nulp(fa.array_from_dim(dim=y_dim, xp=np, space="pos").np_array(space="pos"), y_ref, nulp = 0)
+    np.testing.assert_array_almost_equal_nulp(fa.coords_from_dim(dim=x_dim, xp=np, space="pos").np_array(space="pos"), x_ref, nulp = 0)
+    np.testing.assert_array_almost_equal_nulp(fa.coords_from_dim(dim=y_dim, xp=np, space="pos").np_array(space="pos"), y_ref, nulp = 0)
 
     x_ref_broadcast = x_ref.reshape(1,-1)
     y_ref_broadcast = y_ref.reshape(-1,1)
-    np.testing.assert_array_almost_equal_nulp((fa.array_from_dim(dim=x_dim, xp=np, space="pos") + fa.array_from_dim(dim=y_dim, xp=np, space="pos")).transpose("x", "y").values(space="pos"), (x_ref_broadcast+y_ref_broadcast).transpose(), nulp = 0)
-    np.testing.assert_array_almost_equal_nulp((fa.array_from_dim(dim=x_dim, xp=np, space="pos") + fa.array_from_dim(dim=y_dim, xp=np, space="pos")).transpose("y", "x").values(space="pos"), x_ref_broadcast+y_ref_broadcast, nulp = 0)
+    np.testing.assert_array_almost_equal_nulp((fa.coords_from_dim(dim=x_dim, xp=np, space="pos") + fa.coords_from_dim(dim=y_dim, xp=np, space="pos")).transpose("x", "y").values(space="pos"), (x_ref_broadcast+y_ref_broadcast).transpose(), nulp = 0)
+    np.testing.assert_array_almost_equal_nulp((fa.coords_from_dim(dim=x_dim, xp=np, space="pos") + fa.coords_from_dim(dim=y_dim, xp=np, space="pos")).transpose("y", "x").values(space="pos"), x_ref_broadcast+y_ref_broadcast, nulp = 0)
 
 
 @pytest.mark.parametrize("xp", XPS)
@@ -146,7 +145,7 @@ def test_sel_order(xp, space):
     """
     xdim = fa.dim("x", n=4, d_pos=0.1, pos_min=-0.2, freq_min=-2.1)
     ydim = fa.dim("y", n=8, d_pos=0.03, pos_min=-0.5, freq_min=-4.7)
-    arr = fa.array_from_dim(dim=xdim, xp=xp, space=space) + fa.array_from_dim(dim=ydim, xp=xp, space=space)
+    arr = fa.coords_from_dim(dim=xdim, xp=xp, space=space) + fa.coords_from_dim(dim=ydim, xp=xp, space=space)
     arr_selx = arr.sel(**{"x": getattr(xdim, f"{space}_middle")})
     arr_sely = arr.sel(**{"y": getattr(ydim, f"{space}_middle")})
     arr_selx_sely = arr_selx.sel(**{"y": getattr(ydim, f"{space}_middle")})
@@ -195,7 +194,7 @@ def test_defaults_context() -> None:
 def check_defaults(dim: fa.FFTDimension, xp, dtype_name: DEFAULT_DTYPE, eager: bool) -> None:
     xp_compat = array_api_compat.array_namespace(xp.asarray(0))
     values = 0.1*xp.arange(4, dtype=dtype_name)
-    arr_from_dim = fa.array_from_dim(dim=dim, space="pos")
+    arr_from_dim = fa.coords_from_dim(dim=dim, space="pos")
     arr_direct = fa.array(dims=dim, space="pos", values=values)
     manual_arr = FFTArray(
         values=values,
@@ -219,7 +218,7 @@ def check_defaults(dim: fa.FFTDimension, xp, dtype_name: DEFAULT_DTYPE, eager: b
 
 def test_bool() -> None:
     xdim = fa.dim("x", n=4, d_pos=0.1, pos_min=-0.2, freq_min=-2.1)
-    arr = fa.array_from_dim(dim=xdim, xp=np, space="pos")
+    arr = fa.coords_from_dim(dim=xdim, xp=np, space="pos")
     with pytest.raises(ValueError):
         bool(arr)
 
@@ -260,12 +259,14 @@ def fftarray_strategy(draw) -> FFTArray:
 
     if not all(factors_applied):
         fftarr_values = xp.astype(fftarr_values, xp.complex128)
-    return fa.array(
-        values=fftarr_values,
-        dims=dims,
-        space=init_space,
-        eager=eager,
-        factors_applied=factors_applied,
+    return (
+        fa.array(
+            values=fftarr_values,
+            dims=dims,
+            space=init_space,
+        )
+        .as_factors_applied(factors_applied=factors_applied)
+        .as_eager(eager=eager)
     )
 
 @pytest.mark.slow
@@ -301,7 +302,7 @@ def test_fftarray_lazyness_reduced(xp, precision, space, eager, factors_applied)
     xdim = fa.dim("x", n=4, d_pos=0.1, pos_min=-0.2, freq_min=-2.1)
     ydim = fa.dim("y", n=8, d_pos=0.03, pos_min=-0.5, freq_min=-4.7)
     dtype = getattr(xp, precision)
-    fftarr = fa.array_from_dim(dim=xdim, xp=xp, dtype=dtype, space=space, eager=eager) + fa.array_from_dim(dim=ydim, xp=xp, dtype=dtype, space=space, eager=eager)
+    fftarr = fa.coords_from_dim(dim=xdim, xp=xp, dtype=dtype, space=space).as_eager(eager=eager) + fa.coords_from_dim(dim=ydim, xp=xp, dtype=dtype, space=space).as_eager(eager=eager)
     # TODO: This tests either float without factors or complex with factors.
     if factors_applied:
         fftarr=fftarr.as_factors_applied(factors_applied)
@@ -313,7 +314,7 @@ def test_fftarray_lazyness_reduced(xp, precision, space, eager, factors_applied)
 @pytest.mark.parametrize("xp", XPS)
 def test_immutability(xp) -> None:
     xdim = fa.dim("x", n=4, d_pos=0.1, pos_min=-0.2, freq_min=-2.1)
-    arr = fa.array_from_dim(dim=xdim, xp=xp, dtype=xp.float64, space="pos")
+    arr = fa.coords_from_dim(dim=xdim, xp=xp, dtype=xp.float64, space="pos")
     values = arr.values(space="pos")
     assert arr.values(space="pos")[0] == -0.2
     try:
@@ -567,7 +568,7 @@ def test_fft_ifft_invariance(xp, space: Space):
     """
     xdim = fa.dim("x", n=4, d_pos=0.1, pos_min=-0.2, freq_min=-2.1)
     ydim = fa.dim("y", n=8, d_pos=0.03, pos_min=-0.4, freq_min=-4.2)
-    arr = fa.array_from_dim(dim=xdim, xp=xp, space=space) + fa.array_from_dim(dim=ydim, xp=xp, space=space)
+    arr = fa.coords_from_dim(dim=xdim, xp=xp, space=space) + fa.coords_from_dim(dim=ydim, xp=xp, space=space)
     other_space = get_other_space(space)
     arr_fft = arr.into(space=other_space)
     arr_fft_ifft = arr_fft.into(space=space)
@@ -585,7 +586,7 @@ def test_np_array(xp, spaces: Tuple[Space, Space], precision: PrecisionSpec):
     """Tests if `FFTArray.np_array` returns the values as a NumPy array and if it has the correct precision.
     """
     xdim = fa.dim("x", n=4, d_pos=0.1, pos_min=-0.2, freq_min=-2.1)
-    arr = fa.array_from_dim(dim=xdim, xp=xp, dtype=getattr(xp, precision), space=spaces[0])
+    arr = fa.coords_from_dim(dim=xdim, xp=xp, dtype=getattr(xp, precision), space=spaces[0])
 
     np_arr_same = arr.np_array(space=spaces[0])
     assert isinstance(np_arr_same, np.ndarray)
@@ -621,7 +622,7 @@ try:
 
         xdim = fa.dim("x", n=4, d_pos=0.1, pos_min=-0.2, freq_min=-2.1, dynamically_traced_coords=dtc)
         ydim = fa.dim("y", n=8, d_pos=0.03, pos_min=-0.4, freq_min=-4.2, dynamically_traced_coords=dtc)
-        fftarr = fa.array_from_dim(dim=xdim, xp=jnp, space=space) + fa.array_from_dim(dim=ydim, xp=jnp, space=space)
+        fftarr = fa.coords_from_dim(dim=xdim, xp=jnp, space=space) + fa.coords_from_dim(dim=ydim, xp=jnp, space=space)
 
         def jax_scan_step_fun_dynamic(carry, *_):
             # dynamic should support resizing and shifting of the grid
@@ -658,7 +659,7 @@ def test_different_dimension_dynamic_prop() -> None:
     """
     x_dim = fa.dim(name="x", pos_min=0, freq_min=0, d_pos=1, n=8, dynamically_traced_coords=False)
     y_dim = fa.dim(name="y", pos_min=0, freq_min=0, d_pos=1, n=4, dynamically_traced_coords=True)
-    fftarr = fa.array_from_dim(dim=x_dim, xp=jnp, space="pos") + fa.array_from_dim(dim=y_dim, xp=jnp, space="pos")
+    fftarr = fa.coords_from_dim(dim=x_dim, xp=jnp, space="pos") + fa.coords_from_dim(dim=y_dim, xp=jnp, space="pos")
 
     def jax_scan_step_fun_valid(carry, *_):
         xval = carry._dims[0]._pos_min + carry._dims[0]._d_pos # static dimension

--- a/fftarray/tests/test_fft_array_indexing.py
+++ b/fftarray/tests/test_fft_array_indexing.py
@@ -115,7 +115,7 @@ def test_errors_fftarray_index_substepping(
     as_dict: bool,
 ) -> None:
 
-    fft_arr = fa.array_from_dim(dim=TEST_FFTDIM, xp=xp, space=space)
+    fft_arr = fa.coords_from_dim(dim=TEST_FFTDIM, xp=xp, space=space)
 
     if as_dict:
         invalid_slice = {"x": invalid_slice} # type: ignore
@@ -450,7 +450,7 @@ def test_fftarray_state_management(
         for dim_name in space_combination
     }
     fft_arrays = {
-        dim_name: fa.array_from_dim(dim=dims[dim_name], space=space, xp=xp, eager=False)
+        dim_name: fa.coords_from_dim(dim=dims[dim_name], space=space, xp=xp).as_eager(eager=False)
         for dim_name, space in space_combination.items()
     }
 
@@ -535,7 +535,7 @@ def generate_test_fftarray_xrdataset(
         for dim_name, dim_length in zip(dimension_names, dimension_length, strict=True)
     ]
 
-    fft_array = reduce(lambda x,y: x+y, [fa.array_from_dim(dim=dim, xp=xp, space="pos") for dim in dims])
+    fft_array = reduce(lambda x,y: x+y, [fa.coords_from_dim(dim=dim, xp=xp, space="pos") for dim in dims])
 
     pos_coords = {
         f"{dim.name}_pos": dim.np_array(space="pos")
@@ -573,7 +573,7 @@ try:
         return obj.sel(idx)
 
     def test_invalid_tracer_index() -> None:
-        fft_arr = fa.array_from_dim(dim=TEST_FFTDIM, xp=jnp, space="pos")
+        fft_arr = fa.coords_from_dim(dim=TEST_FFTDIM, xp=jnp, space="pos")
         tracer_index = jax.numpy.array(3)
 
         with pytest.raises(NotImplementedError):

--- a/fftarray/tests/test_fft_array_int.py
+++ b/fftarray/tests/test_fft_array_int.py
@@ -48,9 +48,7 @@ def fftarray_strategy_int(draw) -> FFTArray:
         values=fftarr_values,
         dims=dims,
         space=init_space,
-        eager=eager,
-        factors_applied=True,
-    )
+    ).as_eager(eager=eager)
 
 
 @pytest.mark.slow

--- a/fftarray/tests/test_fft_dimension.py
+++ b/fftarray/tests/test_fft_dimension.py
@@ -66,14 +66,14 @@ def test_arrays(xp) -> None:
         n = n,
     )
 
-    pos_grid = fa.array_from_dim(dim=fftdim, xp=xp, space="pos").np_array(space="pos")
+    pos_grid = fa.coords_from_dim(dim=fftdim, xp=xp, space="pos").np_array(space="pos")
     assert_scalars_almost_equal_nulp(fftdim.pos_min, np.min(pos_grid))
     assert_scalars_almost_equal_nulp(fftdim.pos_min, pos_grid[0])
     assert_scalars_almost_equal_nulp(fftdim.pos_max, np.max(pos_grid))
     assert_scalars_almost_equal_nulp(fftdim.pos_max, pos_grid[-1])
     assert_scalars_almost_equal_nulp(fftdim.pos_middle, pos_grid[int(n/2)])
 
-    freq_grid = fa.array_from_dim(dim=fftdim, xp=xp, space="freq").np_array(space="freq")
+    freq_grid = fa.coords_from_dim(dim=fftdim, xp=xp, space="freq").np_array(space="freq")
     assert_scalars_almost_equal_nulp(fftdim.freq_min, np.min(freq_grid))
     assert_scalars_almost_equal_nulp(fftdim.freq_min, freq_grid[0])
     assert_scalars_almost_equal_nulp(fftdim.freq_max, np.max(freq_grid))

--- a/fftarray/tools.py
+++ b/fftarray/tools.py
@@ -39,7 +39,7 @@ def shift_freq(x: FFTArray, offsets: Dict[str, float]) -> FFTArray:
         )
     phase_shift = fa.full([], [], 1., xp=x.xp, dtype=x.dtype)
     for dim_name, offset in offsets.items():
-        x_arr = fa.coords_array(x, dim_name=dim_name, space="pos").astype("complex")
+        x_arr = fa.coords_from_arr(x, dim_name=dim_name, space="pos").astype("complex")
         phase_shift = phase_shift * fa.exp(1.j * offset * 2*np.pi * x_arr)
     return x.into(space="pos") * phase_shift
 
@@ -77,7 +77,7 @@ def shift_pos(x: FFTArray, offsets: Dict[str, float]) -> FFTArray:
 
     phase_shift = fa.full([], [], 1., xp=x.xp, dtype=x.dtype)
     for dim_name, offset in offsets.items():
-        f_arr = fa.coords_array(x, dim_name=dim_name, space="freq").astype("complex")
+        f_arr = fa.coords_from_arr(x, dim_name=dim_name, space="freq").astype("complex")
         phase_shift = phase_shift * fa.exp(-1.j * offset * 2*np.pi * f_arr)
     return x.into(space="freq") * phase_shift
 

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -1,6 +1,7 @@
 from typing import Iterable, List, Literal, Union, get_args
 
 import numpy as np
+import pytest
 
 import fftarray as fa
 from fftarray.fft_array import FFTArray
@@ -21,6 +22,36 @@ DTYPE_NAME = Literal[
     "complex128",
 ]
 dtypes_names_all = get_args(DTYPE_NAME)
+dtypes_names_numeric_core = [
+    "int32",
+    "int64",
+    "uint32",
+    "uint64",
+    "float32",
+    "float64",
+    "complex64",
+    "complex128",
+]
+dtypes_names_pairs = [
+    pytest.param("bool", "bool"),
+    pytest.param("bool", None),
+    *[
+            pytest.param("uint8", x) for x in [
+            "int32",
+            "uint64",
+            None,
+        ]
+    ],
+    *[
+        pytest.param("float32", x) for x in [
+            "float32",
+            "float64",
+            "complex64",
+            "complex128",
+            None,
+        ]
+    ],
+]
 
 
 def get_dims(n: int) -> List[fa.FFTDimension]:
@@ -49,7 +80,7 @@ def get_arr_from_dims(
         space=[],
     )
     for dim, space in zip(dims, spaces_norm, strict=True):
-        arr += fa.array_from_dim(dim=dim, space=space, xp=xp)
+        arr += fa.coords_from_dim(dim=dim, space=space, xp=xp)
     return arr
 
 def assert_fa_array_exact_equal(x1: FFTArray, x2: FFTArray) -> None:

--- a/tests/unit/test_array.py
+++ b/tests/unit/test_array.py
@@ -17,23 +17,3 @@ def test_astype(xp, init_dtype_name, target_dtype_name) -> None:
     )
     arr2 = arr1.astype(getattr(xp, target_dtype_name))
     assert arr2.dtype == getattr(xp, target_dtype_name)
-
-@pytest.mark.parametrize("xp", XPS)
-@pytest.mark.parametrize("init_dtype_name", ["complex64", "complex128"])
-@pytest.mark.parametrize("target_dtype_name", dtypes_names_all)
-def test_astype_no_factors(xp, init_dtype_name, target_dtype_name) -> None:
-    dim = fa.dim("x", 4, 0.1, 0., 0.)
-    arr1 = fa.array(
-        xp.asarray([0, 1,2,3], dtype=getattr(xp, init_dtype_name)),
-        dims=[dim],
-        space="pos",
-        factors_applied=False,
-    )
-
-    target_dtype = getattr(xp, target_dtype_name)
-    if xp.isdtype(target_dtype, "complex floating"):
-        arr2 = arr1.astype(target_dtype)
-        assert arr2.dtype == target_dtype
-    else:
-        with pytest.raises(ValueError):
-            arr2 = arr1.astype(target_dtype)

--- a/tests/unit/test_creation.py
+++ b/tests/unit/test_creation.py
@@ -1,0 +1,333 @@
+from typing import Iterable, Literal, Optional, Dict, Any, Union, List
+
+import numpy as np
+import pytest
+import fftarray as fa
+
+from fftarray.fft_dimension import FFTDimension
+from fftarray.tests.helpers import XPS, XPS_ROTATED_PAIRS
+from tests.helpers  import get_dims, dtypes_names_pairs, dtypes_names_numeric_core, DTYPE_NAME
+
+
+@pytest.mark.parametrize("xp_target, xp_other", XPS_ROTATED_PAIRS)
+@pytest.mark.parametrize("xp_source", ["values", "direct"])
+@pytest.mark.parametrize("init_dtype_name, result_dtype_name", dtypes_names_pairs)
+@pytest.mark.parametrize("ndims", [0,1,2])
+@pytest.mark.parametrize("defensive_copy", [False, True])
+@pytest.mark.parametrize("eager", [False, True])
+def test_from_array_object(
+        xp_target,
+        xp_other,
+        xp_source: Literal["values", "direct"],
+        init_dtype_name: DTYPE_NAME,
+        result_dtype_name: Optional[DTYPE_NAME],
+        ndims: int,
+        defensive_copy: bool,
+        eager: bool,
+    ) -> None:
+    """
+        Test array creation from an Array API array.
+        This has two cases for xp derivation:
+        1) From the passed in array.
+        2) Via direct override.
+        The default xp is only used when constructing an Array from Python values
+        which is tested in the list creation tests.
+    """
+    dims = get_dims(ndims)
+    shape = tuple(dim.n for dim in dims)
+
+    array_args: Dict[str, Any] = dict(
+        dims=dims,
+        space="pos",
+        defensive_copy=defensive_copy,
+    )
+
+    if result_dtype_name is None:
+        # result_dtype_name is None means that the dtype is inferred from
+        # the passed in values.
+        # Therefore the expected dtype is the same than the one that is used
+        # to create the array.
+        result_dtype = getattr(xp_target, init_dtype_name)
+    else:
+        # In this case we explicitly override the dtype
+        # in the creation of the array.
+        result_dtype = getattr(xp_target, result_dtype_name)
+        array_args["dtype"] = result_dtype
+
+
+    match xp_source:
+        case "values":
+            # We derive xp from the passed in values => create it with the target_xp
+            xp_init = xp_target
+
+        case "direct":
+            # We override the xp from the passed in values => create it with the other_xp,
+            # so that we explicitly use that case.
+            xp_init = xp_other
+            array_args["xp"] = xp_target
+
+    values = xp_init.full(shape, 1., dtype=getattr(xp_init, init_dtype_name))
+    array_args["values"] = values
+
+    # Eager is always inferred from the default setting since there is no override parameter.
+    with fa.default_eager(eager):
+        arr = fa.array(**array_args)
+
+    assert arr.xp == xp_target
+    assert arr.dtype == result_dtype
+    assert arr.shape == shape
+    assert arr.eager == (eager,)*ndims
+
+    # Do the exact same path that the values in the test pass through
+    # just directly in the array API namespace.
+    # That way we ensure that type promotion and conversion via fftarray
+    # work the same way as with the underlying libraries.
+    values = xp_init.full(shape, 1., dtype=getattr(xp_init, init_dtype_name))
+    values_ref = xp_target.asarray(values, copy=True)
+
+    try:
+        # For array libraries with immutable arrays (e.g. jax), we assume this fails.
+        # In these cases, we skip testing immutability ourself.
+        values += 2
+    except(TypeError):
+        pass
+
+    if defensive_copy:
+        assert xp_target.all(arr.values(space="pos") == values_ref)
+    # If not copy, we cannot test for inequality because aliasing behavior
+    # is not defined and for jax for example an inequality check would fail.
+
+    if ndims > 0:
+        wrong_shape = list(shape)
+        wrong_shape[0] = 10
+        values = xp_target.full(tuple(wrong_shape), 1., dtype=result_dtype)
+        with pytest.raises(ValueError):
+            arr = fa.array(
+                values=values,
+                dims=dims,
+                space="pos",
+            )
+
+@pytest.mark.parametrize("xp_target, xp_other", XPS_ROTATED_PAIRS)
+@pytest.mark.parametrize("xp_source", ["default", "direct"])
+@pytest.mark.parametrize("defensive_copy", [False, True])
+@pytest.mark.parametrize("dtype_name", dtypes_names_numeric_core)
+@pytest.mark.parametrize("eager", [False, True])
+def test_from_list(
+        xp_target,
+        xp_other,
+        xp_source: Literal["default", "direct"],
+        defensive_copy: bool,
+        dtype_name: DTYPE_NAME,
+        eager: bool,
+    ) -> None:
+    """
+        Test array creation from a list.
+        This has two cases for xp derivation:
+        1) From default xp.
+        2) Via direct override.
+    """
+
+    dtype = getattr(xp_target, dtype_name)
+    x_dim = fa.dim("x", n=3, d_pos=0.1, pos_min=0, freq_min=0)
+    y_dim = fa.dim("y", n=2, d_pos=0.1, pos_min=0, freq_min=0)
+
+    array_args = dict(
+        defensive_copy=defensive_copy,
+        dtype=dtype,
+    )
+
+
+    match xp_source:
+        case "default":
+            default_xp = xp_target
+        case "direct":
+            default_xp = xp_other
+            array_args["xp"] = xp_target
+
+    check_array_from_list(
+        xp_target=xp_target,
+        default_xp=default_xp,
+        dims=[x_dim],
+        vals_list = [1,2,3],
+        array_args=array_args,
+        dtype=dtype,
+        eager=eager,
+    )
+    check_array_from_list(
+        xp_target=xp_target,
+        default_xp=default_xp,
+        dims=[x_dim, y_dim],
+        vals_list = [[1,4],[2,5],[3,6]],
+        array_args=array_args,
+        dtype=dtype,
+        eager=eager,
+    )
+
+
+    with fa.default_eager(eager):
+        with fa.default_xp(default_xp):
+            # Test that inhomogeneous list triggers the correct error.
+            with pytest.raises(ValueError):
+                fa.array(
+                    values=[1,[2]],
+                    dims=[x_dim],
+                    space="pos",
+                    **array_args,
+                )
+
+def check_array_from_list(
+        xp_target,
+        default_xp,
+        dims: Iterable[FFTDimension],
+        vals_list,
+        array_args: Dict[str, Any],
+        dtype,
+        eager: bool,
+    ) -> None:
+    ref_vals = xp_target.asarray(vals_list, dtype=dtype)
+
+    with fa.default_eager(eager):
+        with fa.default_xp(default_xp):
+            arr = fa.array(
+                values=vals_list,
+                dims=dims,
+                space="pos",
+                **array_args,
+            )
+    arr_vals = arr.values(space="pos")
+
+    assert arr.xp == xp_target
+    assert arr.shape == ref_vals.shape
+    assert arr.dtype == ref_vals.dtype
+    assert arr.eager == (eager,)*len(arr.shape)
+    assert type(arr_vals) is type(ref_vals)
+    np.testing.assert_equal(
+        np.array(arr_vals),
+        np.array(vals_list),
+    )
+
+
+@pytest.mark.parametrize("xp", XPS)
+@pytest.mark.parametrize("fill_value, direct_dtype_name",
+    [
+        pytest.param(5, None),
+        pytest.param(5., None),
+        pytest.param(5.+1.j, None),
+        pytest.param(5, "uint32"),
+        pytest.param(5, "int64"),
+        pytest.param(5, "float64"),
+        pytest.param(5, "complex64"),
+        pytest.param(5., "float64"),
+        pytest.param(5., "complex64"),
+        pytest.param(5.+1.j, "complex64"),
+        pytest.param(5.+1.j, "complex128"),
+    ]
+)
+@pytest.mark.parametrize("ndims", [0,1,2])
+@pytest.mark.parametrize("eager", [False, True])
+def test_full_scalar(
+        xp,
+        fill_value,
+        direct_dtype_name: Optional[DTYPE_NAME],
+        ndims: int,
+        eager: bool,
+    ) -> None:
+
+    if direct_dtype_name is None:
+        # dtype not specified, thus should be inferred by xp from the fill_value
+        direct_dtype = None
+        expected_dtype = xp.full(1, fill_value).dtype
+    else:
+        # dtype is explicity specified in array creation, overwrites fill_value dtype
+        direct_dtype = getattr(xp, direct_dtype_name)
+        expected_dtype = direct_dtype
+
+    check_full(
+        xp=xp,
+        fill_value=fill_value,
+        direct_dtype=direct_dtype,
+        expected_dtype=expected_dtype,
+        ndims=ndims,
+        eager=eager,
+    )
+
+@pytest.mark.parametrize("xp, xp_other", XPS_ROTATED_PAIRS)
+@pytest.mark.parametrize("xp_source", ["fill_value", "direct"])
+@pytest.mark.parametrize("init_dtype_name, direct_dtype_name", dtypes_names_pairs)
+@pytest.mark.parametrize("ndims", [0,1,2])
+@pytest.mark.parametrize("eager", [True, False])
+def test_full_array(
+        xp,
+        xp_other,
+        xp_source: Literal["fill_value", "direct"],
+        init_dtype_name: DTYPE_NAME,
+        direct_dtype_name: Optional[DTYPE_NAME],
+        ndims: int,
+        eager: bool,
+    ) -> None:
+
+    match xp_source:
+        case "fill_value":
+            init_xp = xp
+        case "direct":
+            init_xp = xp_other
+
+    # Define xp array according to xp_source with fill_value using init_dtype_name
+    fill_value = init_xp.asarray(5, dtype=getattr(init_xp, init_dtype_name))
+
+    if direct_dtype_name is None:
+        # This case means the result dtype should be inferred from the fill value.
+        expected_dtype = getattr(xp, init_dtype_name)
+        direct_dtype = None
+    else:
+        # This case means the result dtype is explicitly specified by direct_dtype_name.
+        expected_dtype = getattr(xp, direct_dtype_name)
+        direct_dtype = expected_dtype
+
+    check_full(
+        xp=xp,
+        fill_value=fill_value,
+        direct_dtype=direct_dtype,
+        expected_dtype=expected_dtype,
+        ndims=ndims,
+        eager=eager,
+    )
+
+def check_full(
+        xp,
+        fill_value,
+        direct_dtype,
+        expected_dtype,
+        ndims: int,
+        eager: bool,
+    ) -> None:
+
+    dims_list = get_dims(ndims)
+    shape = tuple(dim.n for dim in dims_list)
+
+    if len(dims_list) == 1:
+        dims: Union[FFTDimension, List[FFTDimension]] = dims_list[0]
+    else:
+        dims = dims_list
+
+    with fa.default_eager(eager):
+        arr = fa.full(
+            dim=dims,
+            space="pos",
+            fill_value=fill_value,
+            xp=xp,
+            dtype=direct_dtype,
+        )
+
+    arr_values = arr.values("pos")
+    ref_arr = xp.full(shape, xp.asarray(fill_value, dtype=direct_dtype))
+    assert arr.dtype == expected_dtype
+    assert arr.eager == (eager,)*ndims
+    assert arr.factors_applied == (True,)*ndims
+
+    assert type(ref_arr) is type(arr_values)
+    np.testing.assert_array_equal(
+        np.array(ref_arr),
+        np.array(arr_values),
+    )

--- a/tests/unit/test_tools.py
+++ b/tests/unit/test_tools.py
@@ -30,13 +30,12 @@ def test_shift(
     # It is important to place both spaces symmetrically around zero to prevent aliasing of the test function in
     # both spaces.
     dim = fa.dim_from_constraints(name="x", n=128, d_pos=0.01, pos_middle=0., freq_middle=0.)
-    arr = fa.array_from_dim(
+    arr = fa.coords_from_dim(
         dim=dim,
         space=space,
         xp=xp,
         dtype=init_dtype,
-        eager=eager,
-    )
+    ).as_eager(eager=eager)
 
     # Use a frequency which fits exactly into the domain to allow periodic shifts
     test_frequency = 5*2*np.pi*getattr(dim, f"d_{other_space}")


### PR DESCRIPTION
Stacked PRs:
 * #203
 * #202
 * #200
 * __->__#199
 * #198


--- --- ---

### Update creation functions to new agreed design.


Rename coords creation methods to agreed new names.
Remove eager from creation functions.

This adds a shape-check and options for defensive copying, `xp` and `dtype`.
It also removes the `factors_applied` option since there is no public API to get these values.
If a user really needs that option there is still the `FFTArray` constructor for that.

Co-authored-by: Christian Struckmann <56967696+cstruckmann@users.noreply.github.com>
Co-authored-by: Gabriel Müller 51076825+gabmueller@users.noreply.github.com
