### PR TITLE
Add statistical functions sum, max and integrate.

### DIFF
--- a/fftarray/__init__.py
+++ b/fftarray/__init__.py
@@ -58,6 +58,12 @@ from .creation_functions import (
    coords_from_arr as coords_from_arr,
    full as full,
 )
+from .statistical_functions import (
+    integrate as integrate,
+    max as max,
+    sum as sum,
+)
+
 
 from .tools import (
     shift_freq as shift_freq,

--- a/fftarray/fft_array.py
+++ b/fftarray/fft_array.py
@@ -885,36 +885,6 @@ class FFTArray:
         return transposed_arr
 
 
-
-    #--------------------
-    # Helpers for the implementation
-    #--------------------
-    @property
-    def d_freq(self) -> float:
-        """..
-
-        Returns
-        -------
-        float
-            The product of the `d_freq` of all active dimensions.
-        """
-        return self._xp.prod(
-            self._xp.asarray([fft_dim.d_freq for fft_dim in self._dims])
-        )
-
-    @property
-    def d_pos(self) -> float:
-        """..
-
-        Returns
-        -------
-        float
-            The product of the `d_pos` of all active dimensions.
-        """
-        return self._xp.prod(
-            self._xp.asarray([fft_dim.d_pos for fft_dim in self._dims])
-        )
-
     def np_array(self: FFTArray, space: Union[Space, Iterable[Space]], dtype = None):
         """..
 

--- a/fftarray/statistical_functions.py
+++ b/fftarray/statistical_functions.py
@@ -1,0 +1,134 @@
+from dataclasses import dataclass
+from typing import Iterable, Optional, Union, List, Tuple
+from typing_extensions import assert_never
+
+from fftarray.fft_dimension import FFTDimension
+
+from .fft_array import FFTArray
+from .space import Space
+
+@dataclass
+class SplitArrayMeta:
+    """
+        Internal helper class for the metadata after a reduction operation.
+    """
+    axis: List[int]
+    eager: Tuple[bool, ...]
+    space: Tuple[Space, ...]
+    fft_dims: Tuple[FFTDimension, ...]
+
+def _named_dims_to_axis(x: FFTArray, dim_name: Optional[Union[str, Iterable[str]]]) -> SplitArrayMeta:
+    """
+        Transform dimension names into axis indices and extract
+        all metadata that is kept after the reduction operation.
+
+        The order of `dim_name` is kept to allow precise control in case the underlying implementation
+        is not commutative in axis-order.
+    """
+    if dim_name is None:
+        return SplitArrayMeta(
+            axis=list(range(len(x.shape))),
+            space=tuple([]),
+            fft_dims=tuple([]),
+            eager=tuple([]),
+        )
+
+    if isinstance(dim_name, str):
+        dim_name = [dim_name]
+
+    dim_names = [dim.name for dim in x.dims]
+    axis = []
+    for dim_ident in dim_name:
+        dim_idx = dim_names.index(dim_ident)
+        axis.append(dim_idx)
+
+    fft_dims = []
+    spaces = []
+    eagers = []
+    for fft_dim, space, eager in zip(x.dims, x.space, x.eager, strict=True):
+        if fft_dim.name not in dim_name:
+            fft_dims.append(fft_dim)
+            spaces.append(space)
+            eagers.append(eager)
+
+    return SplitArrayMeta(
+        axis=axis,
+        space=tuple(spaces),
+        fft_dims=tuple(fft_dims),
+        eager=tuple(eagers),
+    )
+
+def sum(
+        x: FFTArray,
+        *,
+        dim_name: Optional[Union[str, Iterable[str]]] = None,
+        dtype = None,
+    ) -> FFTArray:
+
+    res_meta = _named_dims_to_axis(x, dim_name)
+
+    reduced_values = x.xp.sum(x.values(space=x.space), axis=tuple(res_meta.axis), dtype=dtype)
+
+    return FFTArray(
+        values=reduced_values,
+        space=res_meta.space,
+        dims=res_meta.fft_dims,
+        eager=res_meta.eager,
+        factors_applied=(True,)*len(res_meta.fft_dims),
+        xp=x.xp,
+    )
+
+def max(
+        x: FFTArray,
+        *,
+        dim_name: Optional[Union[str, Iterable[str]]] = None,
+    ) -> FFTArray:
+
+    res_meta = _named_dims_to_axis(x, dim_name)
+
+    reduced_values = x.xp.max(x.values(space=x.space), axis=tuple(res_meta.axis))
+
+    return FFTArray(
+        values=reduced_values,
+        space=res_meta.space,
+        dims=res_meta.fft_dims,
+        eager=res_meta.eager,
+        factors_applied=(True,)*len(res_meta.fft_dims),
+        xp=x.xp,
+    )
+
+def integrate(
+        x: FFTArray,
+        *,
+        dim_name: Optional[Union[str, Iterable[str]]] = None,
+        dtype = None,
+    ) -> FFTArray:
+    """
+        Does a simple rectangle rule integration.
+        Automatically uses the `d_pos` or `d_freq` of the integrated dimension
+        depending on the space the dimension is in at the time of integration.
+    """
+    res_meta = _named_dims_to_axis(x, dim_name)
+
+    integration_element = 1.
+    for i in res_meta.axis:
+        space = x.space[i]
+        match space:
+            case "pos":
+                integration_element *= x.dims[i].d_pos
+            case "freq":
+                integration_element *= x.dims[i].d_freq
+            case _:
+                assert_never(space)
+
+    reduced_values = x.xp.sum(x.values(space=x.space), axis=tuple(res_meta.axis), dtype=dtype)
+    reduced_values *= integration_element
+
+    return FFTArray(
+        values=reduced_values,
+        space=res_meta.space,
+        dims=res_meta.fft_dims,
+        eager=res_meta.eager,
+        factors_applied=(True,)*len(res_meta.fft_dims),
+        xp=x.xp,
+    )

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -22,7 +22,7 @@ DTYPE_NAME = Literal[
     "complex128",
 ]
 dtypes_names_all = get_args(DTYPE_NAME)
-dtypes_names_numeric_core = [
+dtype_names_numeric_core = [
     "int32",
     "int64",
     "uint32",
@@ -66,6 +66,7 @@ def get_arr_from_dims(
         spaces: Union[fa.Space, Iterable[fa.Space]] = "pos",
         dtype_name: DTYPE_NAME = "float64",
     ):
+    dtype=getattr(xp, dtype_name)
     dims = list(dims)
     if isinstance(spaces, str):
         spaces_norm: Iterable[fa.Space] = [spaces]*len(dims)
@@ -74,13 +75,13 @@ def get_arr_from_dims(
     arr = fa.array(
         values=xp.asarray(
             1.,
-            dtype=getattr(xp, dtype_name)
+            dtype=dtype,
         ),
         dims=[],
         space=[],
     )
     for dim, space in zip(dims, spaces_norm, strict=True):
-        arr += fa.coords_from_dim(dim=dim, space=space, xp=xp)
+        arr += fa.coords_from_dim(dim=dim, space=space, xp=xp).astype(dtype=dtype)
     return arr
 
 def assert_fa_array_exact_equal(x1: FFTArray, x2: FFTArray) -> None:

--- a/tests/unit/test_creation.py
+++ b/tests/unit/test_creation.py
@@ -6,7 +6,7 @@ import fftarray as fa
 
 from fftarray.fft_dimension import FFTDimension
 from fftarray.tests.helpers import XPS, XPS_ROTATED_PAIRS
-from tests.helpers import get_dims, dtypes_names_pairs, dtypes_names_numeric_core, DTYPE_NAME
+from tests.helpers import get_dims, dtypes_names_pairs, dtype_names_numeric_core, DTYPE_NAME
 
 
 @pytest.mark.parametrize("xp_target, xp_other", XPS_ROTATED_PAIRS)
@@ -111,7 +111,7 @@ def test_from_array_object(
 @pytest.mark.parametrize("xp_target, xp_other", XPS_ROTATED_PAIRS)
 @pytest.mark.parametrize("xp_source", ["default", "direct"])
 @pytest.mark.parametrize("defensive_copy", [False, True])
-@pytest.mark.parametrize("dtype_name", dtypes_names_numeric_core)
+@pytest.mark.parametrize("dtype_name", dtype_names_numeric_core)
 @pytest.mark.parametrize("eager", [False, True])
 def test_from_list(
         xp_target,

--- a/tests/unit/test_statistical.py
+++ b/tests/unit/test_statistical.py
@@ -1,0 +1,311 @@
+from functools import reduce
+from typing import List, Optional, Any, Union, Tuple, get_args, Iterable
+
+import array_api_strict
+import numpy as np
+import pytest
+import fftarray as fa
+from fftarray._utils.helpers import norm_space
+
+from fftarray.tests.helpers import XPS
+from tests.helpers  import get_dims, get_arr_from_dims, dtype_names_numeric_core, DTYPE_NAME
+
+function_dtypes = {
+    "max": ("integral", "real floating"),
+}
+
+reduction_dims_combinations = [
+    pytest.param(0, tuple([])),
+    pytest.param(0, None),
+    pytest.param(1, tuple([])),
+    pytest.param(1, None),
+    pytest.param(1, tuple([0])),
+    pytest.param(1, 0),
+    pytest.param(2, tuple([])),
+    pytest.param(2, None),
+    pytest.param(2, 1),
+    pytest.param(2, tuple([0])),
+    pytest.param(2, tuple([1,0])),
+]
+
+source_and_res_dtype_name_pairs = [
+    pytest.param("float32", "float64", None),
+    pytest.param("float32", None, None),
+    pytest.param("float64", "float32", None),
+    pytest.param("bool", "float32", TypeError),
+    pytest.param("complex128", "complex64", None),
+]
+
+def _get_dim_names(indices: Optional[Union[int, Tuple[int]]]) -> Optional[Union[str, List[str]]]:
+    if indices is None:
+        return None
+
+    if isinstance(indices, int):
+        return str(indices)
+
+    return [str(i) for i in indices]
+
+def _to_integers(indices: Optional[Union[int, Tuple[int]]], ndims: int) -> Tuple[int, ...]:
+    if indices is None:
+        return tuple(range(ndims))
+
+    if isinstance(indices, int):
+        return (indices,)
+
+    return tuple(indices)
+
+@pytest.mark.parametrize("xp", XPS)
+# Will be extended to include prod
+@pytest.mark.parametrize("op_name", ["sum"])
+@pytest.mark.parametrize(
+    "source_dtype_name, acc_dtype_name, should_raise",
+    source_and_res_dtype_name_pairs
+)
+@pytest.mark.parametrize("ndims, reduction_dims", reduction_dims_combinations)
+@pytest.mark.parametrize("attribute_inversion", [False, True])
+def test_sum(
+        xp,
+        op_name,
+        source_dtype_name: DTYPE_NAME,
+        acc_dtype_name: Optional[DTYPE_NAME],
+        should_raise: Optional[Any],
+        ndims: int,
+        reduction_dims: Optional[Union[int, Tuple[int]]],
+        attribute_inversion: bool,
+    ) -> None:
+    source_dtype = getattr(xp, source_dtype_name)
+    if acc_dtype_name is None:
+        acc_dtype = None
+    else:
+        acc_dtype = getattr(xp, acc_dtype_name)
+    dims = get_dims(ndims)
+    arr = get_arr_from_dims(xp, dims, spaces="pos").astype(source_dtype)
+
+    # Just set alternating attributes in order to save on iterations.
+    arr_attributes = [((i%2)==0)^attribute_inversion for i in range(ndims)]
+    arr = arr.as_eager(arr_attributes)
+    if xp.isdtype(source_dtype, "complex floating"):
+        arr = arr.as_factors_applied(arr_attributes)
+    arr = arr.transpose(*[dim.name for dim in dims])
+
+    if should_raise is not None:
+        if xp == array_api_strict:
+            with pytest.raises(should_raise):
+                getattr(fa, op_name)(arr, dim_name=_get_dim_names(reduction_dims), dtype=acc_dtype)
+        return
+
+    fa_res = getattr(fa, op_name)(arr, dim_name=_get_dim_names(reduction_dims), dtype=acc_dtype)
+    fa_res_values = fa_res.values(space="pos")
+
+    ref_input = arr.values("pos")
+    ref_res = getattr(xp, op_name)(ref_input, axis=reduction_dims, dtype=acc_dtype)
+
+    ref_attributes = tuple(
+        x for (i, x) in enumerate(arr_attributes)
+        if i not in _to_integers(indices=reduction_dims, ndims=ndims)
+    )
+    assert fa_res.eager == ref_attributes
+    # This will be changed at a later point to actually be conserved.
+    assert fa_res.factors_applied == (True,)*len(ref_attributes)
+
+    if len(fa_res_values.shape) > 0:
+        assert type(ref_res) is type(fa_res_values)
+
+    np.testing.assert_equal(
+        np.array(ref_res),
+        np.array(fa_res_values),
+    )
+
+@pytest.mark.parametrize("xp", XPS)
+# Will be extended to min and mean
+@pytest.mark.parametrize("op_name", ["max"])
+@pytest.mark.parametrize("dtype_name", dtype_names_numeric_core)
+@pytest.mark.parametrize("ndims, reduction_dims", reduction_dims_combinations)
+@pytest.mark.parametrize("attribute_inversion", [False, True])
+def test_max(
+        xp,
+        op_name: str,
+        dtype_name: DTYPE_NAME,
+        ndims: int,
+        reduction_dims: Optional[Union[int, Tuple[int]]],
+        attribute_inversion: bool,
+    ) -> None:
+    dtype = getattr(xp, dtype_name)
+    dims = get_dims(ndims)
+    arr = get_arr_from_dims(xp, dims, spaces="pos").astype(dtype)
+    # Just set alternating attributes in order to save on iterations.
+    arr_attributes = [((i%2)==0)^attribute_inversion for i in range(ndims)]
+    arr = arr.as_eager(arr_attributes)
+    if xp.isdtype(dtype, "complex floating"):
+        arr = arr.as_factors_applied(arr_attributes)
+    arr = arr.transpose(*[dim.name for dim in dims])
+
+    if not xp.isdtype(dtype, function_dtypes[op_name]):
+        if xp == array_api_strict:
+            with pytest.raises(TypeError):
+                getattr(fa, op_name)(arr, dim=_get_dim_names(reduction_dims))
+        return
+
+    fa_res = getattr(fa, op_name)(arr, dim_name=_get_dim_names(reduction_dims))
+    fa_res_values = fa_res.values(space="pos")
+
+    ref_input = arr.values("pos")
+    ref_res = getattr(xp, op_name)(ref_input, axis=reduction_dims)
+
+    ref_attributes = tuple(
+        x for (i, x) in enumerate(arr_attributes)
+        if i not in _to_integers(indices=reduction_dims, ndims=ndims)
+    )
+    assert fa_res.eager == ref_attributes
+    # This will be changed at a later point to actually be conserved.
+    assert fa_res.factors_applied == (True,)*len(ref_attributes)
+
+    if len(fa_res_values.shape) > 0:
+        assert type(ref_res) is type(fa_res_values)
+
+    np.testing.assert_equal(
+        np.array(ref_res),
+        np.array(fa_res_values),
+    )
+
+@pytest.mark.parametrize("xp", XPS)
+@pytest.mark.parametrize(
+    "source_dtype_name, acc_dtype_name, should_raise",
+    source_and_res_dtype_name_pairs
+)
+@pytest.mark.parametrize("space", get_args(fa.Space))
+@pytest.mark.parametrize("ndims, reduction_dims", reduction_dims_combinations)
+@pytest.mark.parametrize("attribute_inversion", [False, True])
+def test_integrate_base(
+        xp,
+        source_dtype_name: DTYPE_NAME,
+        acc_dtype_name: Optional[DTYPE_NAME],
+        should_raise: Optional[Any],
+        space: Union[fa.Space, Iterable[fa.Space]],
+        ndims: int,
+        reduction_dims: Optional[Union[int, Tuple[int]]],
+        attribute_inversion: bool,
+    ) -> None:
+
+    check_integrate(
+        xp=xp,
+        source_dtype_name=source_dtype_name,
+        acc_dtype_name=acc_dtype_name,
+        should_raise=should_raise,
+        space=space,
+        ndims=ndims,
+        reduction_dims=reduction_dims,
+        attribute_inversion=attribute_inversion,
+    )
+
+@pytest.mark.parametrize(
+    "source_dtype_name, acc_dtype_name, should_raise",
+    source_and_res_dtype_name_pairs
+)
+@pytest.mark.parametrize("ndims, reduction_dims, space",
+    [
+        pytest.param(2, tuple([0]), ("pos", "freq")),
+        pytest.param(2, tuple([1,0]), ("pos", "freq")),
+        pytest.param(3, tuple([0,2]), ("freq", "freq", "pos")),
+    ]
+)
+@pytest.mark.parametrize("attribute_inversion", [False, True])
+def test_integrate_mixed_space(
+        source_dtype_name: DTYPE_NAME,
+        acc_dtype_name: Optional[DTYPE_NAME],
+        should_raise: Optional[Any],
+        space: Union[fa.Space, Iterable[fa.Space]],
+        ndims: int,
+        reduction_dims: Optional[Union[int, Tuple[int]]],
+        attribute_inversion: bool,
+    ) -> None:
+
+    check_integrate(
+        xp=array_api_strict,
+        source_dtype_name=source_dtype_name,
+        acc_dtype_name=acc_dtype_name,
+        should_raise=should_raise,
+        space=space,
+        ndims=ndims,
+        reduction_dims=reduction_dims,
+        attribute_inversion=attribute_inversion,
+    )
+
+
+def check_integrate(
+        xp,
+        source_dtype_name: DTYPE_NAME,
+        acc_dtype_name: Optional[DTYPE_NAME],
+        should_raise: Optional[Any],
+        space: Union[fa.Space, Iterable[fa.Space]],
+        ndims: int,
+        reduction_dims: Optional[Union[int, Tuple[int]]],
+        attribute_inversion: bool,
+    ) -> None:
+
+    space_norm = norm_space(val=space, n=ndims)
+    source_dtype = getattr(xp, source_dtype_name)
+    if acc_dtype_name is None:
+        acc_dtype = None
+    else:
+        acc_dtype = getattr(xp, acc_dtype_name)
+    dims = get_dims(ndims)
+    arr = get_arr_from_dims(xp, dims, spaces=space_norm).astype(source_dtype)
+    # Just set alternating attributes in order to save on iterations.
+    arr_attributes = [((i%2)==0)^attribute_inversion for i in range(ndims)]
+    arr = arr.as_eager(arr_attributes)
+    if xp.isdtype(source_dtype, "complex floating"):
+        arr = arr.as_factors_applied(arr_attributes)
+    arr = arr.transpose(*[dim.name for dim in dims])
+
+    if should_raise is not None:
+        if xp == array_api_strict:
+            with pytest.raises(should_raise):
+                fa.integrate(arr, dim_name=_get_dim_names(reduction_dims), dtype=acc_dtype)
+        return
+
+    fa_res = fa.integrate(arr, dim_name=_get_dim_names(reduction_dims), dtype=acc_dtype)
+    res_space = tuple(
+        x for (i, x) in enumerate(space_norm)
+        if i not in _to_integers(indices=reduction_dims, ndims=ndims)
+    )
+    fa_res_values = fa_res.values(space=res_space)
+
+    ref_input = arr.values(space=space)
+    ref_res = xp.sum(ref_input, axis=reduction_dims, dtype=acc_dtype)
+    if reduction_dims is None:
+        integration_element = reduce(
+            lambda a,b: a*b,
+            [getattr(dim, f"d_{dim_space}") for dim, dim_space in zip(dims, space_norm, strict=True)],
+            1.
+        )
+    elif isinstance(reduction_dims, int):
+        integration_element = getattr(dims[reduction_dims], f"d_{space_norm[reduction_dims]}")
+    else:
+        integration_element = reduce(
+            lambda a,b: a*b,
+            [
+                getattr(dim, f"d_{space_norm[dim_idx]}")
+                for dim_idx, dim in enumerate(dims)
+                if dim_idx in reduction_dims
+            ],
+            1.,
+        )
+    ref_res = ref_res * xp.asarray(integration_element, dtype=ref_res.dtype)
+
+    ref_attributes = tuple(
+        x for (i, x) in enumerate(arr_attributes)
+        if i not in _to_integers(indices=reduction_dims, ndims=ndims)
+    )
+    assert fa_res.space == res_space
+    assert fa_res.eager == ref_attributes
+    # This will be changed at a later point to actually be conserved.
+    assert fa_res.factors_applied == (True,)*len(ref_attributes)
+
+    if len(fa_res_values.shape) > 0:
+        assert type(ref_res) is type(fa_res_values)
+
+    np.testing.assert_equal(
+        np.array(ref_res),
+        np.array(fa_res_values),
+    )


### PR DESCRIPTION
Stacked PRs:
 * __->__#202
 * #203


--- --- ---

### Add statistical functions sum, max and integrate.


Currently only `sum`, `max` and `integrate`.
`prod`, `min` and `mean` will be added in a second commit when this one is through.
Remove the member methods `d_pos` and `d_freq` since they are not needed anymore with Array API support and integrate.

Co-authored-by: Christian Struckmann <56967696+cstruckmann@users.noreply.github.com>
Co-authored-by: Gabriel Müller <51076825+gabmueller@users.noreply.github.com>
