### PR TITLE
add `norm_space`

### DIFF
--- a/fftarray/_utils/helpers.py
+++ b/fftarray/_utils/helpers.py
@@ -1,6 +1,39 @@
-from typing import TypeVar, Union, Iterable, Tuple
+from typing import TypeVar, Union, Iterable, Tuple, get_args, cast
+
+from ..space import Space
 
 T = TypeVar("T")
+
+
+space_args = get_args(Space)
+def _check_space(x: str) -> Space:
+    if x not in space_args:
+        raise ValueError(f"Only valid values for space are: {space_args}. Got passed '{x}'.")
+    return cast(Space, x)
+
+def norm_space(val: Union[Space, Iterable[Space]], n: int) -> Tuple[Space, ...]:
+    """
+       `val` has to be immutable.
+    """
+
+    if isinstance(val, str):
+        return (_check_space(val),)*n
+
+    try:
+        input_list = list(val)
+    except(TypeError) as e:
+        raise TypeError(
+            f"Got passed '{val}' as space which raised an error on iteration."
+        ) from e
+
+    res_tuple = tuple(_check_space(x) for x in input_list)
+
+    if len(res_tuple) != n:
+        raise ValueError(
+            f"Got passed '{val}' as space which has length {len(res_tuple)} "
+            + f"but there are {n} dimensions."
+        )
+    return res_tuple
 
 def norm_param(val: Union[T, Iterable[T]], n: int, types) -> Tuple[T, ...]:
     """

--- a/fftarray/creation_functions.py
+++ b/fftarray/creation_functions.py
@@ -7,7 +7,7 @@ from .fft_array import FFTArray
 from .space import Space
 from .transform_application import real_type
 from ._utils.defaults import get_default_eager, get_default_dtype_name, get_default_xp
-from ._utils.helpers import norm_param
+from ._utils.helpers import norm_space
 
 def _get_xp(xp: Optional[Any], values) -> Tuple[Any, bool]:
     used_default_xp = False
@@ -94,7 +94,7 @@ def array(
             raise exc
 
     n_dims = len(dims_tuple)
-    spaces_normalized: Tuple[Space, ...] = norm_param(space, n_dims, str)
+    spaces_normalized: Tuple[Space, ...] = norm_space(space, n_dims)
     for sub_space in spaces_normalized:
         assert sub_space in get_args(Space)
 
@@ -278,7 +278,7 @@ def full(
     arr = FFTArray(
         values=values,
         dims=dims,
-        space=norm_param(space, n_dims, str),
+        space=norm_space(space, n_dims),
         eager=(get_default_eager(),)*n_dims,
         factors_applied=(True,)*n_dims,
         xp=xp,

--- a/fftarray/fft_array.py
+++ b/fftarray/fft_array.py
@@ -24,7 +24,7 @@ from ._utils.indexing import (
     LocFFTArrayIndexer, check_missing_dim_names,
     tuple_indexers_from_dict_or_tuple, tuple_indexers_from_mapping,
 )
-from ._utils.helpers import norm_param
+from ._utils.helpers import norm_param, norm_space
 from .op_lazy_luts import (
     TwoOperandTransforms,
     default_transforms_lut,
@@ -681,7 +681,7 @@ class FFTArray:
             Use `.into(factors_applied=True)` if you want to evaluate it once and reuse it multiple times.
         """
 
-        space_norm: Tuple[Space, ...] = norm_param(space, len(self.dims), str)
+        space_norm: Tuple[Space, ...] = norm_space(space, len(self.dims))
         if space_norm != self.space or not all(self._factors_applied):
             # Setting eager before-hand allows copy-elision without the move option.
             fft_arr = self.as_eager(True).into(space=space).as_factors_applied(True)
@@ -822,7 +822,7 @@ class FFTArray:
 
         dims = self._dims
         n_dims = len(dims)
-        space_after: Tuple[Space, ...] = norm_param(space, n_dims, str)
+        space_after = norm_space(space, n_dims)
 
         needs_fft = [old != new for old, new in zip(self._spaces, space_after, strict=True)]
         if not any(needs_fft):

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -1,0 +1,38 @@
+import pytest
+
+from fftarray._utils.helpers import _check_space, norm_space
+
+def test_check_space() -> None:
+    assert _check_space("pos") == "pos"
+    assert _check_space("freq") == "freq"
+    with pytest.raises(ValueError):
+        _check_space(5) # type: ignore
+    with pytest.raises(ValueError):
+        _check_space("pos2")
+
+def test_norm_space() -> None:
+
+    assert norm_space("freq", 0) == tuple()
+    assert norm_space("pos", 0) == tuple()
+    assert norm_space("pos", 1) == ("pos",)
+    assert norm_space("freq", 1) == ("freq",)
+    assert norm_space("pos", 2) == ("pos",)*2
+    assert norm_space("freq", 2) == ("freq",)*2
+
+    assert norm_space(["pos"], 1) == ("pos",)
+    assert norm_space(["freq"], 1) == ("freq",)
+    assert norm_space(["pos", "freq"], 2) == ("pos", "freq")
+    assert norm_space(["freq", "freq"], 2) == ("freq", "freq")
+
+    with pytest.raises(TypeError):
+        norm_space(5, 0) # type: ignore
+    with pytest.raises(TypeError):
+        norm_space(5, 1) # type: ignore
+    with pytest.raises(ValueError):
+        norm_space("pos2", 0) # type: ignore
+    with pytest.raises(ValueError):
+        norm_space("pos2", 1) # type: ignore
+    with pytest.raises(ValueError):
+        norm_space(["pos"], 2)
+    with pytest.raises(ValueError):
+        norm_space(["pos", "freq"], 1)


### PR DESCRIPTION
Stacked PRs:
 * #202
 * __->__#203


--- --- ---

### add `norm_space`


This replaces `norm_param` to provide better error messages and more precise typing.
The other of `norm_param` will be adjusted similarly.

Co-authored-by: Gabriel Müller <51076825+gabmueller@users.noreply.github.com>
