### PR TITLE
Fix `run_all_checks_all_python_versions.sh`

### DIFF
--- a/run_all_checks_all_python_versions.sh
+++ b/run_all_checks_all_python_versions.sh
@@ -1,4 +1,6 @@
-pixi run -e doc doc  && continue || exit 1
-for pyenv in check310 check311 check312 check313; do
+# This script aims to run the whole test suite locally to prevent surprises in CI.
+pixi run -e doc doc_local && continue || exit 1
+pixi run -e doc doc_all_versions && continue || exit 1
+for pyenv in checknumpy125 check310 check311 check312 check313; do
   (command pixi run -e $pyenv check_all) && continue || exit 1
 done


### PR DESCRIPTION
Adds a little comment, explainign what it does.
This was not adjusted when changing the doc build process.