### PR TITLE
Reduce number of tests by only testing against array_api_strict in more places.

### DIFF
--- a/tests/other/test_array_ops.py
+++ b/tests/other/test_array_ops.py
@@ -23,7 +23,7 @@ precisions: List[PrecisionSpec] = ["float32", "float64"]
 spaces: List[fa.Space] = ["pos", "freq"]
 
 
-@pytest.mark.parametrize("xp", XPS)
+@pytest.mark.parametrize("xp", [array_api_strict])
 @pytest.mark.parametrize("space", ["pos", "freq"])
 def test_comparison(xp, space) -> None:
     x_dim = fa.dim("x",
@@ -192,7 +192,7 @@ def test_broadcasting(xp) -> None:
     np.testing.assert_array_equal(xzy_yx.values("pos"), xzy_yx_ref_xzy, strict=True)
 
 
-@pytest.mark.parametrize("xp", XPS)
+@pytest.mark.parametrize("xp", [array_api_strict])
 @pytest.mark.parametrize("space", spaces)
 def test_sel_order(xp, space) -> None:
     """Tests whether the selection order matters. Assuming an input Array of
@@ -346,7 +346,7 @@ def test_array_lazyness(arr):
         # -- test eager, factors_applied logic
         assert_array_eager_factors_applied(arr, note)
 
-@pytest.mark.parametrize("xp", XPS)
+@pytest.mark.parametrize("xp", [array_api_strict])
 @pytest.mark.parametrize("precision", precisions)
 @pytest.mark.parametrize("space", spaces)
 @pytest.mark.parametrize("eager", [True, False])
@@ -614,7 +614,7 @@ def assert_array_eager_factors_applied(arr: fa.Array, log):
         assert (feager and ffapplied) or (not feager and not ffapplied)
 
 
-@pytest.mark.parametrize("xp", XPS)
+@pytest.mark.parametrize("xp", [array_api_strict])
 @pytest.mark.parametrize("space", spaces)
 def test_fft_ifft_invariance(xp, space: fa.Space):
     """Tests whether ifft(fft(*)) is an identity.

--- a/tests/other/test_dimension.py
+++ b/tests/other/test_dimension.py
@@ -1,11 +1,11 @@
 import copy
 
+import array_api_strict
 import numpy as np
 import pytest
 import jax
 
 import fftarray as fa
-from tests.helpers import XPS
 
 jax.config.update("jax_enable_x64", True)
 
@@ -51,7 +51,7 @@ def test_dim_jax():
     assert jax_func(dim) == dim
 
 
-@pytest.mark.parametrize("xp", XPS)
+@pytest.mark.parametrize("xp", [array_api_strict])
 def test_arrays(xp) -> None:
     """
     Test that the manual arrays and the performance-optimized kernels create the same values in the supplied direction.

--- a/tests/other/test_indexing.py
+++ b/tests/other/test_indexing.py
@@ -1,12 +1,13 @@
 
 from functools import reduce
 from typing import Dict, List, Literal, Mapping, Tuple, TypeVar, Union
+
+import array_api_strict
 import pytest
 import numpy as np
 import xarray as xr
 
 import fftarray as fa
-from tests.helpers import XPS
 
 EllipsisType = TypeVar('EllipsisType')
 
@@ -104,7 +105,7 @@ invalid_substepping_slices = [
 ]
 
 @pytest.mark.parametrize("as_dict", [True, False])
-@pytest.mark.parametrize("xp", XPS)
+@pytest.mark.parametrize("xp", [array_api_strict])
 @pytest.mark.parametrize("invalid_slice", invalid_substepping_slices)
 @pytest.mark.parametrize("space", ["pos", "freq"])
 def test_errors_array_index_substepping(
@@ -142,7 +143,7 @@ invalid_tuples = [
     (slice(None, None), slice(None, None), Ellipsis),
 ]
 
-@pytest.mark.parametrize("xp", XPS)
+@pytest.mark.parametrize("xp", [array_api_strict])
 @pytest.mark.parametrize("invalid_tuple", invalid_tuples)
 @pytest.mark.parametrize("space", ["pos", "freq"])
 def test_errors_array_invalid_indexes(
@@ -212,7 +213,7 @@ integer_indexers_test_samples = [
 ]
 
 @pytest.mark.parametrize("indexers", integer_indexers_test_samples)
-@pytest.mark.parametrize("xp", XPS)
+@pytest.mark.parametrize("xp", [array_api_strict])
 @pytest.mark.parametrize("space", ["pos", "freq"])
 def test_3d_array_indexing_by_integer(
     space: fa.Space,
@@ -268,7 +269,7 @@ tuple_indexers = [
 ]
 
 @pytest.mark.parametrize("indexers", tuple_indexers)
-@pytest.mark.parametrize("xp", XPS)
+@pytest.mark.parametrize("xp", [array_api_strict])
 @pytest.mark.parametrize("space", ["pos", "freq"])
 def test_3d_array_positional_indexing(
     space: fa.Space,
@@ -310,7 +311,7 @@ label_indexers_test_samples = [
 ]
 
 @pytest.mark.parametrize("indexers", label_indexers_test_samples)
-@pytest.mark.parametrize("xp", XPS)
+@pytest.mark.parametrize("xp", [array_api_strict])
 @pytest.mark.parametrize("space", ["pos", "freq"])
 @pytest.mark.parametrize("method", ["nearest", "pad", "ffill", "backfill", "bfill", None, "unsupported"])
 def test_3d_array_label_indexing(
@@ -352,7 +353,7 @@ def test_3d_array_label_indexing(
 @pytest.mark.parametrize("indexers", label_indexers_test_samples)
 @pytest.mark.parametrize("index_by", ["label", "integer"])
 @pytest.mark.parametrize("space", ["pos", "freq"])
-@pytest.mark.parametrize("xp", XPS)
+@pytest.mark.parametrize("xp", [array_api_strict])
 def test_3d_array_indexing(
     space: fa.Space,
     index_by: Literal["label", "integer"],
@@ -433,7 +434,7 @@ space_combinations = [
 ]
 
 @pytest.mark.parametrize("indexers", valid_indexers)
-@pytest.mark.parametrize("xp", XPS)
+@pytest.mark.parametrize("xp", [array_api_strict])
 @pytest.mark.parametrize("space_combination", space_combinations)
 def test_array_state_management(
     space_combination: Dict[str, fa.Space],

--- a/tests/unit/test_array.py
+++ b/tests/unit/test_array.py
@@ -1,6 +1,7 @@
 from typing import List, get_args
 import itertools
 
+import array_api_strict
 import pytest
 import numpy as np
 
@@ -31,7 +32,7 @@ def test_into_dtype(xp, init_dtype_name, target_dtype_name) -> None:
 
 
 
-@pytest.mark.parametrize("xp", XPS)
+@pytest.mark.parametrize("xp", [array_api_strict])
 @pytest.mark.parametrize("ndims, permutation",
     [
         pytest.param(ndims, permutation)

--- a/tests/unit/test_elementwise.py
+++ b/tests/unit/test_elementwise.py
@@ -7,7 +7,7 @@ import numpy as np
 import fftarray as fa
 
 from tests.helpers import (
-    XPS, assert_fa_array_exact_equal, get_test_array
+    assert_fa_array_exact_equal, get_test_array
 )
 from fftarray._src.transform_application import complex_type
 
@@ -76,7 +76,7 @@ single_operand_lambdas = {
 }
 
 
-@pytest.mark.parametrize("xp", XPS)
+@pytest.mark.parametrize("xp", [array_api_strict])
 @pytest.mark.parametrize("op_name", elementwise_ops_single_arg_full)
 @pytest.mark.parametrize("eager", [True, False])
 @pytest.mark.parametrize("space", get_args(fa.Space))
@@ -103,7 +103,7 @@ def test_elementwise_single_arg_full_complex(
     )
 
 
-@pytest.mark.parametrize("xp", XPS)
+@pytest.mark.parametrize("xp", [array_api_strict])
 @pytest.mark.parametrize("op_name", elementwise_ops_single_arg_full)
 @pytest.mark.parametrize("space", get_args(fa.Space))
 @pytest.mark.parametrize("dtype_name", ["bool", "int64", "float64"])
@@ -265,7 +265,7 @@ def get_two_operand_same_dim_transform_factors(
             return (True,)
 
 
-@pytest.mark.parametrize("xp", XPS)
+@pytest.mark.parametrize("xp", [array_api_strict])
 @pytest.mark.parametrize("op_name", elementwise_ops_single_arg_sparse)
 @pytest.mark.parametrize("dtype_name", ["bool", "int64", "float64", "complex128"])
 def test_elementwise_single_arg_sparse(
@@ -349,7 +349,7 @@ def elementwise_single_arg(
         np.array(xp_res),
     )
 
-@pytest.mark.parametrize("xp", XPS)
+@pytest.mark.parametrize("xp", [array_api_strict])
 @pytest.mark.parametrize("space", get_args(fa.Space))
 @pytest.mark.parametrize("eager", [True, False])
 @pytest.mark.parametrize("factors_applied_1", [True, False])
@@ -373,7 +373,7 @@ def test_elementwise_two_arrs_full_complex(
         dtype_name="complex128",
     )
 
-@pytest.mark.parametrize("xp", XPS)
+@pytest.mark.parametrize("xp", [array_api_strict])
 @pytest.mark.parametrize("space", get_args(fa.Space))
 @pytest.mark.parametrize("op_name", elementwise_ops_double_arg_full)
 @pytest.mark.parametrize("dtype_name", ["bool", "int64", "float64"])
@@ -398,7 +398,7 @@ def test_elementwise_two_arrs_full(
     )
 
 
-@pytest.mark.parametrize("xp", XPS)
+@pytest.mark.parametrize("xp", [array_api_strict])
 @pytest.mark.parametrize("op_name", elementwise_ops_double_arg_sparse)
 @pytest.mark.parametrize("dtype_name", ["bool", "int64", "float64", "complex128"])
 def test_elementwise_two_arrs_sparse(
@@ -540,7 +540,7 @@ dtype_scalar_combinations_complex = [
     pytest.param("complex128", 5.+1.j),
 ]
 
-@pytest.mark.parametrize("xp", XPS)
+@pytest.mark.parametrize("xp", [array_api_strict])
 @pytest.mark.parametrize("space", get_args(fa.Space))
 @pytest.mark.parametrize("op_idxs", [(0,1), (1,0)])
 @pytest.mark.parametrize("op_name", elementwise_ops_double_arg_full_dunder)
@@ -566,7 +566,7 @@ def test_elementwise_arr_scalar_full(
         dtype_name=dtype_name,
     )
 
-@pytest.mark.parametrize("xp", XPS)
+@pytest.mark.parametrize("xp", [array_api_strict])
 @pytest.mark.parametrize("space", get_args(fa.Space))
 @pytest.mark.parametrize("eager", [True, False])
 @pytest.mark.parametrize("factors_applied", [True, False])
@@ -595,7 +595,7 @@ def test_elementwise_arr_scalar_full_complex(
         dtype_name=dtype_name,
     )
 
-@pytest.mark.parametrize("xp", XPS)
+@pytest.mark.parametrize("xp", [array_api_strict])
 @pytest.mark.parametrize("op_idxs", [(0,1), (1,0)])
 @pytest.mark.parametrize("op_name", elementwise_ops_double_arg_sparse_dunder)
 @pytest.mark.parametrize("dtype_name, scalar_value", [
@@ -696,7 +696,7 @@ def elementwise_arr_scalar(
     )
 
 
-@pytest.mark.parametrize("xp", XPS)
+@pytest.mark.parametrize("xp", [array_api_strict])
 def test_clip(xp) -> None:
     dim1 = fa.dim("x", 4, 0.1, 0., 0.)
     vals = xp.asarray([1,2,3,4])
@@ -705,7 +705,7 @@ def test_clip(xp) -> None:
     assert xp.all(fa.clip(arr1, min=None, max=3).values("pos") == xp.clip(vals, min=None, max=3))
     assert xp.all(fa.clip(arr1).values("pos") == xp.clip(vals))
 
-@pytest.mark.parametrize("xp", XPS)
+@pytest.mark.parametrize("xp", [array_api_strict])
 @pytest.mark.parametrize("precision", ["float32", "float64"])
 @pytest.mark.parametrize("type, factors_applied", [
     pytest.param("real", True),

--- a/tests/unit/test_format.py
+++ b/tests/unit/test_format.py
@@ -1,10 +1,11 @@
+import array_api_strict
 import pytest
 
 from fftarray._src.dimension import Dimension
 from fftarray._src.formatting import format_bytes, format_n
-from tests.helpers import XPS, get_dims, get_arr_from_dims
+from tests.helpers import get_dims, get_arr_from_dims
 
-@pytest.mark.parametrize("xp", XPS)
+@pytest.mark.parametrize("xp", [array_api_strict])
 def test_format(xp) -> None:
     """
         Tests that `__str__` and `__repr__` of `Dimension`

--- a/tests/unit/test_manipulation.py
+++ b/tests/unit/test_manipulation.py
@@ -1,13 +1,14 @@
 from typing import Any, Tuple
 from itertools import permutations
 
+import array_api_strict
 import pytest
 import numpy as np
 
 import fftarray as fa
-from tests.helpers import XPS, get_dims, get_arr_from_dims
+from tests.helpers import get_dims, get_arr_from_dims
 
-@pytest.mark.parametrize("xp", XPS)
+@pytest.mark.parametrize("xp", [array_api_strict])
 @pytest.mark.parametrize("ndims, permuted_axes",
     [pytest.param(nd, perm) for nd in [0,1,2,3] for perm in permutations(range(nd))]
 )

--- a/tests/unit/test_statistical.py
+++ b/tests/unit/test_statistical.py
@@ -7,7 +7,7 @@ import pytest
 import fftarray as fa
 from fftarray._src.helpers import norm_space
 
-from tests.helpers import XPS, get_dims, get_arr_from_dims, dtype_names_numeric_core, DTYPE_NAME
+from tests.helpers import get_dims, get_arr_from_dims, dtype_names_numeric_core, DTYPE_NAME
 
 function_dtypes = {
     "max": ("integral", "real floating"),
@@ -55,7 +55,7 @@ def _to_integers(indices: Optional[Union[int, Tuple[int]]], ndims: int) -> Tuple
 
     return tuple(indices)
 
-@pytest.mark.parametrize("xp", XPS)
+@pytest.mark.parametrize("xp", [array_api_strict])
 @pytest.mark.parametrize("op_name", ["sum", "prod"])
 @pytest.mark.parametrize(
     "source_dtype_name, acc_dtype_name, should_raise",
@@ -116,7 +116,7 @@ def test_sum_prod(
         np.array(fa_res_values),
     )
 
-@pytest.mark.parametrize("xp", XPS)
+@pytest.mark.parametrize("xp", [array_api_strict])
 @pytest.mark.parametrize("op_name", ["max", "min", "mean"])
 @pytest.mark.parametrize("dtype_name", dtype_names_numeric_core)
 @pytest.mark.parametrize("ndims, reduction_dims", reduction_dims_combinations)
@@ -167,7 +167,7 @@ def test_max_min_mean(
         np.array(fa_res_values),
     )
 
-@pytest.mark.parametrize("xp", XPS)
+@pytest.mark.parametrize("xp", [array_api_strict])
 @pytest.mark.parametrize(
     "source_dtype_name, acc_dtype_name, should_raise",
     source_and_res_dtype_name_pairs

--- a/tests/unit/test_tools.py
+++ b/tests/unit/test_tools.py
@@ -1,14 +1,15 @@
 from typing import get_args
 
+import array_api_strict
 import pytest
 import numpy as np
 
 import fftarray as fa
 
-from tests.helpers import XPS, get_other_space
+from tests.helpers import get_other_space
 from fftarray._src.transform_application import complex_type
 
-@pytest.mark.parametrize("xp", XPS)
+@pytest.mark.parametrize("xp", [array_api_strict])
 @pytest.mark.parametrize("eager", [True, False])
 @pytest.mark.parametrize("space", get_args(fa.Space))
 @pytest.mark.parametrize("init_dtype_name, atol", [
@@ -55,7 +56,7 @@ def test_shift(
         atol=atol,
     )
 
-@pytest.mark.parametrize("xp", XPS)
+@pytest.mark.parametrize("xp", [array_api_strict])
 @pytest.mark.parametrize("init_dtype_name", ["bool", "int64", "uint64"])
 @pytest.mark.parametrize("space", get_args(fa.Space))
 def test_shift_int(


### PR DESCRIPTION
Stacked PRs:
 * #249
 * #248
 * #247
 * #246
 * #245
 * #244
 * #243
 * #242
 * #241
 * __->__#240


--- --- ---

### Reduce number of tests by only testing against array_api_strict in more places.


We should not aim to test the Array API compliance of all tested libraries
but just our functionality.
