### PR TITLE
Remove default precision

### DIFF
--- a/src/fftarray/__init__.py
+++ b/src/fftarray/__init__.py
@@ -33,13 +33,9 @@ from ._src.defaults import (
     set_default_xp as set_default_xp,
     get_default_xp as get_default_xp,
     default_xp as default_xp,
-    set_default_precision as set_default_precision,
-    get_default_precision as get_default_precision,
-    default_precision as default_precision,
     set_default_eager as set_default_eager,
     get_default_eager as get_default_eager,
     default_eager as default_eager,
-    DEFAULT_PRECISION as DEFAULT_PRECISION,
 )
 
 from ._src.space import Space as Space

--- a/src/fftarray/_src/creation_functions.py
+++ b/src/fftarray/_src/creation_functions.py
@@ -6,7 +6,7 @@ from .dimension import Dimension
 from .array import Array
 from .space import Space
 from .transform_application import real_type
-from .defaults import get_default_eager, get_default_precision, get_default_xp
+from .defaults import get_default_eager, get_default_xp
 from .helpers import norm_space
 
 def _get_xp(xp: Optional[Any], values) -> Tuple[Any, bool]:
@@ -133,7 +133,7 @@ def coords_from_dim(
     xp : Optional[Any]
         The array namespace to use for the returned ``Array``. `None` uses default ``numpy`` which can be globally changed.
     dtype : Optional[Any]
-        The dtype to use for the returned ``Array``. `None` uses default ``float64`` which can be globally changed.
+        The dtype to use for the returned ``Array``. `None` uses the default floating point type of the chosen ``xp``.
 
     Returns
     -------
@@ -149,12 +149,6 @@ def coords_from_dim(
         xp = get_default_xp()
     else:
         xp = array_api_compat.array_namespace(xp.asarray(0))
-
-    if dtype is None:
-        dtype = getattr(xp, get_default_precision())
-
-    if not xp.isdtype(dtype, ("real floating", "complex floating")):
-        raise ValueError(f"Coordinates can only be initialized as real or complex numbers but got passed dtype '{dtype}'")
 
     values = dim.values(space, xp=xp, dtype=dtype)
 

--- a/src/fftarray/_src/defaults.py
+++ b/src/fftarray/_src/defaults.py
@@ -1,4 +1,3 @@
-from typing import Literal, get_args
 
 import numpy as np
 
@@ -30,51 +29,6 @@ class DefaultArrayNamespaceContext:
 
 def default_xp(xp) -> DefaultArrayNamespaceContext:
     return DefaultArrayNamespaceContext(xp=xp)
-
-
-
-"""
-    Only floating types are allowed as default dtypes
-    because only those make sense to initialize coordinate arrays.
-"""
-DEFAULT_PRECISION = Literal[
-    "float32",
-    "float64",
-]
-
-# stores the name of the attribute
-_DEFAULT_PRECISION: DEFAULT_PRECISION = "float64"
-
-def check_precision(precision: DEFAULT_PRECISION):
-    """Helper function checking whether the provided precision is supported."""
-    if precision not in get_args(DEFAULT_PRECISION):
-        raise ValueError(
-            f"Precision '{precision}' is not supported. " +
-            f"Choose one from {get_args(DEFAULT_PRECISION)}."
-        )
-
-def set_default_precision(precision: DEFAULT_PRECISION) -> None:
-    check_precision(precision)
-    global _DEFAULT_PRECISION
-    _DEFAULT_PRECISION = precision
-
-def get_default_precision() -> DEFAULT_PRECISION:
-    return _DEFAULT_PRECISION
-
-class DefaultPrecisionContext:
-    def __init__(self, precision: DEFAULT_PRECISION):
-        self.override = precision
-
-    def __enter__(self):
-        self.previous = get_default_precision()
-        set_default_precision(self.override)
-
-    def __exit__(self, exc_type, exc_val, exc_tb):
-        set_default_precision(self.previous)
-
-def default_precision(precision: DEFAULT_PRECISION) -> DefaultPrecisionContext:
-    check_precision(precision)
-    return DefaultPrecisionContext(precision=precision)
 
 
 _DEFAULT_EAGER: bool = False

--- a/src/fftarray/_src/dimension.py
+++ b/src/fftarray/_src/dimension.py
@@ -4,9 +4,9 @@ from typing_extensions import assert_never
 from dataclasses import dataclass
 
 import numpy as np
-import array_api_compat
+from .defaults import get_default_xp
 
-from .defaults import get_default_precision, get_default_xp
+import array_api_compat
 from .formatting import dim_table, format_n
 from .indexing import check_substepping, remap_index_check_int
 
@@ -590,8 +590,7 @@ class Dimension:
             None, the default namespace from ``get_default_xp()`` is used.
         dtype : Optional[Any], optional
             The dtype to use for the returned values. If it is None, the
-            corresponding real floating point dtype with precision from
-            ``get_default_precision()`` is used.
+            default real floating point dtype of the determined ``xp`` is used.
 
         Returns
         -------
@@ -604,11 +603,11 @@ class Dimension:
         else:
             xp = array_api_compat.array_namespace(xp.asarray(1))
 
-        if dtype is None:
-            dtype = getattr(xp, get_default_precision())
+        if dtype is not None and not xp.isdtype(dtype, "real floating"):
+            raise ValueError("Coordinates can only have a real-valued floating point dtype.")
 
         indices = xp.arange(
-            0,
+            0.,
             self.n,
             dtype=dtype,
         )

--- a/tests/other/test_array_ops.py
+++ b/tests/other/test_array_ops.py
@@ -216,23 +216,20 @@ def test_sel_order(xp, space) -> None:
 def test_defaults() -> None:
     assert fa.get_default_eager() is False
     assert fa.get_default_xp() == array_api_compat.array_namespace(np.asarray(0.))
-    assert fa.get_default_precision() == "float64"
 
     xdim = fa.dim("x", n=4, d_pos=0.1, pos_min=0., freq_min=0.)
 
-    check_defaults(xdim, xp=np, precision="float64", eager=False)
+    check_defaults(xdim, xp=np, eager=False)
 
     fa.set_default_xp(jnp)
-    fa.set_default_precision("float32")
-    check_defaults(xdim, xp=jnp, precision="float32", eager=False)
+    check_defaults(xdim, xp=jnp, eager=False)
 
     fa.set_default_eager(True)
-    check_defaults(xdim, xp=jnp, precision="float32", eager=True)
+    check_defaults(xdim, xp=jnp, eager=True)
 
     # Reset global state for other tests
     fa.set_default_eager(False)
     fa.set_default_xp(np)
-    fa.set_default_precision("float64")
 
 
 
@@ -240,19 +237,17 @@ def test_defaults_context() -> None:
     xdim = fa.dim("x", n=4, d_pos=0.1, pos_min=0., freq_min=0.)
 
     with fa.default_xp(jnp):
-        with fa.default_precision("float32"):
-            check_defaults(xdim, xp=jnp, precision="float32", eager=False)
-    check_defaults(xdim, xp=np, precision="float64", eager=False)
+            check_defaults(xdim, xp=jnp, eager=False)
+    check_defaults(xdim, xp=np, eager=False)
     with fa.default_xp(jnp):
-        with fa.default_precision("float32"):
             with fa.default_eager(eager=True):
-                check_defaults(xdim, xp=jnp, precision="float32", eager=True)
-            check_defaults(xdim, xp=jnp, precision="float32", eager=False)
+                check_defaults(xdim, xp=jnp, eager=True)
+            check_defaults(xdim, xp=jnp, eager=False)
 
 
-def check_defaults(dim: fa.Dimension, xp, precision: fa.DEFAULT_PRECISION, eager: bool) -> None:
+def check_defaults(dim: fa.Dimension, xp, eager: bool) -> None:
     xp_compat = array_api_compat.array_namespace(xp.asarray(0))
-    values = 0.1*xp.arange(4, dtype=precision)
+    values = 0.1*xp.arange(4)
     arr_from_dim = fa.coords_from_dim(dim, "pos")
     arr_direct = fa.array(values, dim, "pos")
     manual_arr = fa.Array(
@@ -265,14 +260,12 @@ def check_defaults(dim: fa.Dimension, xp, precision: fa.DEFAULT_PRECISION, eager
     )
 
     assert fa.get_default_xp() == xp_compat
-    assert fa.get_default_precision() == precision
     assert fa.get_default_eager() == eager
 
     for arr in [arr_from_dim, arr_direct]:
         assert (manual_arr==arr).values("pos").all()
         assert arr.eager == (eager,)
         assert arr.xp == xp_compat
-        assert arr.values("pos").dtype == precision
 
 
 def test_bool() -> None:

--- a/tests/unit/test_tools.py
+++ b/tests/unit/test_tools.py
@@ -7,7 +7,7 @@ import numpy as np
 import fftarray as fa
 
 from tests.helpers import get_other_space
-from fftarray._src.transform_application import complex_type
+from fftarray._src.transform_application import complex_type, real_type
 
 @pytest.mark.parametrize("xp", [array_api_strict])
 @pytest.mark.parametrize("eager", [True, False])
@@ -32,8 +32,8 @@ def test_shift(
     # both spaces.
     dim = fa.dim_from_constraints(name="x", n=128, d_pos=0.01, pos_middle=0., freq_middle=0.)
     arr = fa.coords_from_dim(
-        dim, space, xp=xp, dtype=init_dtype,
-    ).into_eager(eager)
+        dim, space, xp=xp, dtype=real_type(xp, init_dtype),
+    ).into_eager(eager).into_dtype(init_dtype)
 
     # Use a frequency which fits exactly into the domain to allow periodic shifts
     test_frequency = 5*2*np.pi*getattr(dim, f"d_{other_space}")


### PR DESCRIPTION
Stacked PRs:
 * #249
 * #248
 * #247
 * #246
 * #245
 * #244
 * #243
 * #242
 * __->__#241


--- --- ---

### Remove default precision


It is impossible to shield the user from the intricate differences in precision
handling and dtype promotion of different array libraries.
So FFTArray is just a as thin as possible wrapper around the underlying library
and does not interfere there at all.

Co-authored-by: Gabriel Müller <g.mueller@iqo.uni-hannover.de>
Co-authored-by: Christian Struckmann <56967696+cstruckmann@users.noreply.github.com>
