### PR TITLE
Replace numpy in all shape and phase factor calculation with pure python lists.

### DIFF
--- a/src/fftarray/_src/transform_application.py
+++ b/src/fftarray/_src/transform_application.py
@@ -117,7 +117,7 @@ def apply_lazy(
         if sign != 0:
             # Create indices with correct shape
             indices = xp.arange(0, dim.n, dtype=real_type(xp, values.dtype))
-            extended_shape = np.ones(len(values.shape), dtype=int)
+            extended_shape = [1]*len(values.shape)
             extended_shape[dim_idx] = -1
             indices = xp.reshape(indices, shape=tuple(extended_shape))
 


### PR DESCRIPTION
Stacked PRs:
 * #249
 * #248
 * #247
 * #246
 * #245
 * #244
 * __->__#243
 * #242


--- --- ---

### Replace numpy in all shape and phase factor calculation with pure python lists.


This is in preparation for torch.compile which would try to move
the NumPy calculations from trace time to run time.
Additionally it had problems to parse the TwoOperandTransforms class therefore it is replaced
by a tuple of lists.

Co-authored-by: Gabriel Müller <51076825+gabmueller@users.noreply.github.com>
