### PR TITLE
Restructure the use of array_api_compat to a central place

### DIFF
--- a/src/fftarray/_src/array.py
+++ b/src/fftarray/_src/array.py
@@ -8,12 +8,11 @@ from numbers import Number
 from dataclasses import dataclass
 import textwrap
 
-import array_api_compat
-
 from .space import Space
 from .dimension import Dimension
 from .named_array import align_named_arrays
 from .uniform_value import UniformValue
+from .helpers import get_array_compat_namespace, get_compat_namespace
 
 from .formatting import dim_table, format_bytes, format_n
 from .indexing import (
@@ -778,7 +777,7 @@ class Array:
         if xp is None:
             xp = self.xp
         else:
-            xp = array_api_compat.array_namespace(xp.asarray(1))
+            xp = get_compat_namespace(xp)
         space_norm: Tuple[Space, ...] = norm_space(space, len(self.dims))
         if space_norm != self.spaces or not all(self._factors_applied):
             # Setting eager before-hand allows copy-elision without the move option.
@@ -814,7 +813,7 @@ class Array:
             spaces=self._spaces,
             eager=self._eager,
             factors_applied=self._factors_applied,
-            xp=array_api_compat.array_namespace(values),
+            xp=get_array_compat_namespace(values),
         )
 
     @property
@@ -1052,10 +1051,10 @@ class Array:
         assert all([isinstance(factor_applied, bool) for factor_applied in self._factors_applied])
 
         # Check that the Array API namespace is properly wrapped.
-        assert self._xp == array_api_compat.array_namespace(self._xp.asarray(0))
+        assert self._xp == get_compat_namespace(self._xp)
 
         # Check that values are of the stored Array API namespace.
-        assert self._xp == array_api_compat.array_namespace(self._values)
+        assert self._xp == get_array_compat_namespace(self._values)
 
         if not all(self._factors_applied):
             assert self.xp.isdtype(self._values.dtype, 'complex floating')
@@ -1181,7 +1180,7 @@ def unpack_arrays(
     for value in unpacked_values:
         assert value is not None
 
-    assert xp.get() == array_api_compat.array_namespace(xp.get().asarray(0))
+    assert xp.get() == get_compat_namespace(xp.get())
 
     return UnpackedValues(
         dims = tuple(dims_list),

--- a/src/fftarray/_src/creation_functions.py
+++ b/src/fftarray/_src/creation_functions.py
@@ -1,24 +1,23 @@
 from typing import Any, Optional, Union, Iterable, Tuple, get_args
 
-import array_api_compat
 
 from .dimension import Dimension
 from .array import Array
 from .space import Space
 from .transform_application import real_type
 from .defaults import get_default_eager, get_default_xp
-from .helpers import norm_space
+from .helpers import norm_space, get_compat_namespace, get_array_compat_namespace
 
 def _get_xp(xp: Optional[Any], values) -> Tuple[Any, bool]:
     used_default_xp = False
     if xp is None:
         try:
-            xp = array_api_compat.array_namespace(values)
+            xp = get_array_compat_namespace(values)
         except(TypeError):
             xp = get_default_xp()
             used_default_xp = True
     else:
-        xp = array_api_compat.array_namespace(xp.asarray(1))
+        xp = get_compat_namespace(xp)
 
     return xp, used_default_xp
 
@@ -148,7 +147,7 @@ def coords_from_dim(
     if xp is None:
         xp = get_default_xp()
     else:
-        xp = array_api_compat.array_namespace(xp.asarray(0))
+        xp = get_compat_namespace(xp)
 
     values = dim.values(space, xp=xp, dtype=dtype)
 
@@ -209,7 +208,7 @@ def coords_from_arr(
             if xp is None:
                 xp_norm = x.xp
             else:
-                xp_norm = array_api_compat.array_namespace(xp.array(1.))
+                xp_norm = get_compat_namespace(xp)
 
             return coords_from_dim(
                 dim, space, xp=xp_norm, dtype=dtype

--- a/src/fftarray/_src/defaults.py
+++ b/src/fftarray/_src/defaults.py
@@ -1,16 +1,15 @@
 
 import numpy as np
 
-import array_api_compat
-
-_DEFAULT_XP = array_api_compat.array_namespace(np.asarray(0))
+from .helpers import get_compat_namespace
+_DEFAULT_XP = get_compat_namespace(np)
 
 def set_default_xp(xp) -> None:
     global _DEFAULT_XP
     # We want the wrapped namespace everywhere by default.
     # If the array library fully supports the Python Array API
     # this becomes the default namespace.
-    _DEFAULT_XP= array_api_compat.array_namespace(xp.asarray(0))
+    _DEFAULT_XP= get_compat_namespace(xp)
 
 def get_default_xp():
     return _DEFAULT_XP

--- a/src/fftarray/_src/helpers.py
+++ b/src/fftarray/_src/helpers.py
@@ -1,5 +1,7 @@
 from typing import TypeVar, Union, Iterable, Tuple, get_args, cast
 
+import array_api_compat
+
 from .space import Space
 
 T = TypeVar("T")
@@ -44,3 +46,26 @@ def norm_param(val: Union[T, Iterable[T]], n: int, types) -> Tuple[T, ...]:
 
     # TODO: Can we make this type check work?
     return tuple(val) # type: ignore
+
+
+def get_compat_namespace(xp):
+    """
+        Wraps a namespace in a compatibility wrapper if necessary.
+    """
+    return get_array_compat_namespace(xp.asarray(1))
+
+def get_array_compat_namespace(x):
+    """
+        Get the Array API compatible namespace of x.
+        This is basically a single array version of `array_api_compat.array_namespace`.
+        But it has a special case for torch because `array_api_compat.array_namespace`
+        is currently incompatible with `torch.compile`.
+    """
+    # Special case torch array.
+    # As of pytorch 2.6.0 and array_api_compat 1.11.0
+    # torch.compile is not compatible with `array_api_compat.array_namespace`.
+    if array_api_compat.is_torch_array(x):
+        import array_api_compat.torch as torch_namespace
+        return torch_namespace
+
+    return array_api_compat.array_namespace(x)


### PR DESCRIPTION
Stacked PRs:
 * #249
 * #248
 * #247
 * #246
 * #245
 * __->__#244
 * #251


--- --- ---

### Restructure the use of array_api_compat to a central place


In preparation for torch.compile this also adds a workaround with get_array_namespace.
