### PR TITLE
Restructure creation functions

### DIFF
--- a/src/fftarray/_src/array.py
+++ b/src/fftarray/_src/array.py
@@ -12,7 +12,7 @@ from .space import Space
 from .dimension import Dimension
 from .named_array import align_named_arrays
 from .uniform_value import UniformValue
-from .helpers import get_array_compat_namespace, get_compat_namespace
+from .compat_namespace import get_array_compat_namespace, get_compat_namespace
 
 from .formatting import dim_table, format_bytes, format_n
 from .indexing import (

--- a/src/fftarray/_src/compat_namespace.py
+++ b/src/fftarray/_src/compat_namespace.py
@@ -1,0 +1,23 @@
+import array_api_compat
+
+def get_compat_namespace(xp):
+    """
+        Wraps a namespace in a compatibility wrapper if necessary.
+    """
+    return get_array_compat_namespace(xp.asarray(1))
+
+def get_array_compat_namespace(x):
+    """
+        Get the Array API compatible namespace of x.
+        This is basically a single array version of `array_api_compat.array_namespace`.
+        But it has a special case for torch because `array_api_compat.array_namespace`
+        is currently incompatible with `torch.compile`.
+    """
+    # Special case torch array.
+    # As of pytorch 2.6.0 and array_api_compat 1.11.0
+    # torch.compile is not compatible with `array_api_compat.array_namespace`.
+    if array_api_compat.is_torch_array(x):
+        import array_api_compat.torch as torch_namespace
+        return torch_namespace
+
+    return array_api_compat.array_namespace(x)

--- a/src/fftarray/_src/defaults.py
+++ b/src/fftarray/_src/defaults.py
@@ -1,7 +1,6 @@
-
 import numpy as np
 
-from .helpers import get_compat_namespace
+from .compat_namespace import get_compat_namespace
 _DEFAULT_XP = get_compat_namespace(np)
 
 def set_default_xp(xp) -> None:
@@ -52,3 +51,4 @@ class DefaultEagerContext:
 
 def default_eager(eager: bool) -> DefaultEagerContext:
     return DefaultEagerContext(eager=eager)
+

--- a/src/fftarray/_src/dimension.py
+++ b/src/fftarray/_src/dimension.py
@@ -4,9 +4,7 @@ from typing_extensions import assert_never
 from dataclasses import dataclass
 
 import numpy as np
-from .defaults import get_default_xp
-
-import array_api_compat
+from .helpers import norm_xp
 from .formatting import dim_table, format_n
 from .indexing import check_substepping, remap_index_check_int
 
@@ -598,13 +596,13 @@ class Dimension:
             The Dimension's values.
         """
 
-        if xp is None:
-            xp = get_default_xp()
-        else:
-            xp = array_api_compat.array_namespace(xp.asarray(1))
+        xp = norm_xp(xp_arg=xp)
 
         if dtype is not None and not xp.isdtype(dtype, "real floating"):
-            raise ValueError("Coordinates can only have a real-valued floating point dtype.")
+            raise ValueError(
+                "Coordinates can only have a real-valued floating point dtype. " \
+                f"Passed in {dtype}."
+            )
 
         indices = xp.arange(
             0.,


### PR DESCRIPTION
Stacked PRs:
 * #249
 * #248
 * #247
 * #246
 * __->__#245


--- --- ---

### Restructure creation functions


It is impossible to shield the user from the intricate differences in precision
handling and dtype promotion of different array libraries.
So FFTArray is just a as thin as possible wrapper around the underlying library
and does not interfere there at all.
Therefore dtype and device are always just passed through to the underlying library
and the libaries behavior is predictably replicated.

This also fixes the tests of fa.full to follow the behavior of the underlying library
instead of enforcing the specific behavior of keeping the dtype
of a passed in array scalar.

Co-authored-by: Gabriel Müller <51076825+gabmueller@users.noreply.github.com>
Co-authored-by: Christian Struckmann <56967696+cstruckmann@users.noreply.github.com>
