### PR TITLE
Workaround for cross-library conversion

### DIFF
--- a/src/fftarray/_src/array.py
+++ b/src/fftarray/_src/array.py
@@ -9,6 +9,7 @@ from dataclasses import dataclass
 import textwrap
 
 import array_api_compat
+import numpy as np
 
 from .space import Space
 from .dimension import Dimension
@@ -33,7 +34,40 @@ from .transform_application import do_fft, get_transform_signs, apply_lazy, comp
 
 EllipsisType = TypeVar('EllipsisType')
 
+def _convert_xp(x, old_xp, new_xp, dtype: Optional[Any] = None, copy: Optional[bool] = None):
+    """
+        The Array API standard does not support conversion between array namespaces.
+        Therefore this function only supports conversions between libraries where the interaction
+        is specifically allowed. This implementation is currently not optimal for performance
+        and always goes the safe route via NumPy.
+    """
+    if old_xp == new_xp:
+        return new_xp.asarray(x, dtype=dtype, copy=copy)
 
+    if array_api_compat.is_array_api_strict_namespace(old_xp):
+        x_np = array_api_compat.to_device(x, old_xp.__array_namespace_info__().default_device())
+    elif array_api_compat.is_numpy_array(x):
+        x_np = x
+    elif array_api_compat.is_jax_array(x):
+        assert copy is None or copy
+        x_np = np.array(x)
+    else:
+        # TODO: Just raise a warning and try np.array(x)?
+        raise ValueError(
+            f"Tried to convert from {old_xp} " \
+            "which does not have a specific implementation. " \
+            "The Array API standard does not support conversion between array namespaces " \
+            "and there is no specific work-around for this namespace."
+        )
+
+    if (
+        not array_api_compat.is_jax_namespace(new_xp)
+        and not array_api_compat.is_numpy_namespace(new_xp)
+        and not array_api_compat.is_array_api_strict_namespace(new_xp)
+    ):
+        raise ValueError(f"Tried to convert to unsupported namespace {new_xp}.")
+
+    return new_xp.asarray(x_np, dtype=dtype, copy=copy)
 
 def abs(x: Array, /) -> Array:
     """Implements abs with a special shortcut to statically eliminate the phase part
@@ -781,8 +815,8 @@ class Array:
         if space_norm != self.spaces or not all(self._factors_applied):
             # Setting eager before-hand allows copy-elision without the move option.
             arr = self.into_eager(True).into_space(space).into_factors_applied(True)
-            return xp.asarray(arr._values, dtype=dtype)
-        return xp.asarray(self._values, dtype=dtype, copy=True)
+            return _convert_xp(arr._values, old_xp = self.xp, new_xp=xp, dtype=dtype)
+        return _convert_xp(self._values, old_xp = self.xp, new_xp=xp, dtype=dtype, copy=True)
 
     @property
     def xp(self):
@@ -807,9 +841,7 @@ class Array:
             A new Array with the new array API namespace.
         """
         # Since Array is immutable, this does not necessarily need to copy.
-        # Do not explicitly pass copy=None, because numpy 1.25 does not
-        # support that argument.
-        values = xp.asarray(self._values)
+        values = _convert_xp(self._values, old_xp=self.xp, new_xp=xp, copy=None)
         return Array(
             dims=self._dims,
             values=values,

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -2,10 +2,12 @@ from typing import Iterable, List, Literal, Union, Tuple, Any, Optional
 
 import array_api_strict
 import array_api_compat
+import array_api_compat.numpy as cnp
 import numpy as np
 import pytest
 
 import fftarray as fa
+from fftarray._src.array import _convert_xp
 
 XPS = [
     array_api_strict,
@@ -173,13 +175,9 @@ def assert_fa_array_exact_equal(x1: fa.Array, x2: fa.Array) -> None:
     assert x1.device == x2.device
 
 
-    # FIXME: Technically this does not guarantuee convertability into NumPy
-    # for any Array API compatible library.
-    # But this works for the tested libraries.
-    default_device = x1._xp.__array_namespace_info__().default_device()
     np.testing.assert_equal(
-        np.array(array_api_compat.to_device(x1._values, default_device)),
-        np.array(array_api_compat.to_device(x2._values, default_device)),
+        _convert_xp(x1._values, old_xp=x1._xp, new_xp=cnp),
+        _convert_xp(x2._values, old_xp=x1._xp, new_xp=cnp),
     )
 
 def get_test_array(

--- a/tests/unit/test_creation.py
+++ b/tests/unit/test_creation.py
@@ -3,10 +3,11 @@ from typing import (
 )
 
 import array_api_strict
-import array_api_compat
+import array_api_compat.numpy as cnp
 import numpy as np
 import pytest
 import fftarray as fa
+from fftarray._src.array import _convert_xp
 
 from tests.helpers import (
     XPS_WITH_DEFAULT_DEVICE_PAIRS, XPS_ROTATED_PAIRS, XPS_DEVICE_PAIRS, XPS_NON_DEFAULT_DEVICE_PAIRS,
@@ -191,8 +192,8 @@ def check_array_from_list(
     assert arr.eager == (eager,)*len(arr.shape)
     assert type(arr_vals) is type(ref_vals)
     np.testing.assert_equal(
-        np.array(arr_vals),
-        np.array(vals_list),
+        _convert_xp(arr_vals, old_xp=arr.xp, new_xp=cnp),
+        _convert_xp(ref_vals, old_xp=xp_target, new_xp=cnp),
     )
 
 
@@ -304,12 +305,9 @@ def check_full(
 
     assert type(ref_arr) is type(arr_values)
 
-    # FIXME: Technically this does not guarantuee convertability into NumPy
-    # for any Array API compatible library.
-    default_device = xp.__array_namespace_info__().default_device()
     np.testing.assert_equal(
-        np.array(array_api_compat.to_device(ref_arr, default_device)),
-        np.array(array_api_compat.to_device(arr_values, default_device)),
+        _convert_xp(ref_arr, old_xp=xp, new_xp=cnp),
+        _convert_xp(arr_values, old_xp=xp, new_xp=cnp),
     )
 
 

--- a/tests/unit/test_manipulation.py
+++ b/tests/unit/test_manipulation.py
@@ -3,9 +3,12 @@ from itertools import permutations
 
 import array_api_strict
 import pytest
+import array_api_compat.numpy as cnp
 import numpy as np
 
 import fftarray as fa
+from fftarray._src.array import _convert_xp
+
 from tests.helpers import get_dims, get_arr_from_dims
 
 @pytest.mark.parametrize("xp", [array_api_strict])
@@ -46,6 +49,6 @@ def test_permute_dims(xp: Any, ndims: int, permuted_axes: Tuple[int]) -> None:
     assert values_ref.shape == values_permuted.shape
     assert arr_permuted.shape == tuple(arr_before.shape[a] for a in permuted_axes)
     np.testing.assert_equal(
-        np.array(values_permuted),
-        np.array(values_ref),
+        _convert_xp(values_permuted, old_xp=xp, new_xp=cnp),
+        _convert_xp(values_ref, old_xp=xp, new_xp=cnp),
     )


### PR DESCRIPTION
Stacked PRs:
 * #249
 * __->__#248
 * #247
 * #246


--- --- ---

### Workaround for cross-library conversion


Since it does not accept arbitrary Python Array API implementations this should
be fully conformant and not suddenly break.

This patch comes before pytorch because then we can keep the xp conversion tests as is.

I am not decided on where to best put this this function and whether to expose it externally.
There are some potential performance improvements for it in the future because for example cupy and pytorch
can exchange CUDA arrays.
But for simplicity this optimization is not done here.
