### PR TITLE
Fix pip_test on github

### DIFF
--- a/.github/workflows/pip_test.yml
+++ b/.github/workflows/pip_test.yml
@@ -4,8 +4,7 @@
 name: Run pytest via pip
 
 on:
-  push:
-    branches: [ "main" ]
+  pull_request:
 
 permissions:
   contents: read
@@ -25,6 +24,9 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
+        python -m pip install torch==2.6.0
+        python -m pip install array_api_strict==2.3.1
+        python -m pip install jax==0.5.3
         python -m pip install -e ".[check]"
     - name: Test with pytest
       run: |


### PR DESCRIPTION
Stacked PRs:
 * #264
 * #263
 * #262
 * #261
 * #260
 * #258
 * #259
 * __->__#257


--- --- ---

### Fix pip_test on github


Enable the pip_test on each pull request.
Install torch 2.6.0 manually before running the tests.
Version 2.4.0 of array-api-strict also broke a few things, so fix it to 2.3.1 in order to get a minimum working version.
Jax 0.6.2 also breaks a test, fix it to the 0.5.3 from the pixi.lock for now and it will be updated in a later PR.
