### PR TITLE
Change dynamically_traced_coords default to False

### DIFF
--- a/examples/Bragg_beam_splitter.ipynb
+++ b/examples/Bragg_beam_splitter.ipynb
@@ -176,7 +176,6 @@
     "    freq_middle = 0.,\n",
     "    freq_extent = 32*k_L,\n",
     "    loose_params = [\"freq_extent\"],\n",
-    "    dynamically_traced_coords=False\n",
     ")\n",
     "\n",
     "# initialize an Array as harmonic oscillator groundstate\n",

--- a/src/fftarray/__init__.py
+++ b/src/fftarray/__init__.py
@@ -162,7 +162,7 @@ except ModuleNotFoundError:
          freq_extent: Optional[float] = None,
          freq_middle: Optional[float] = None,
          loose_params: Optional[Union[str, List[str]]] = None,
-         dynamically_traced_coords: bool = True,
+         dynamically_traced_coords: bool = False,
     ) -> Dimension:
       raise ModuleNotFoundError("You need to install `fftarray[helpers]` to use the constraint solver.")
 

--- a/src/fftarray/_src/constraint_solver.py
+++ b/src/fftarray/_src/constraint_solver.py
@@ -72,7 +72,7 @@ def dim_from_constraints(
         freq_extent: Optional[float] = None,
         freq_middle: Optional[float] = None,
         loose_params: Optional[Union[str, List[str]]] = None,
-        dynamically_traced_coords: bool = True,
+        dynamically_traced_coords: bool = False,
     ) -> Dimension:
     """Creates a Dimension from an arbitrary subset of all possible grid
     parameters using the z3 constraint solver. Note that the specified grid
@@ -132,7 +132,7 @@ def dim_from_constraints(
     dynamically_traced_coords : bool, optional
         Only relevant for use with JAX tracing. Whether the coordinate values should be
         dynamically traced such that the grid can be altered inside a jitted
-        function, by default True
+        function, by default False
 
     Returns
     -------

--- a/src/fftarray/_src/dimension.py
+++ b/src/fftarray/_src/dimension.py
@@ -18,7 +18,7 @@ def dim(
         pos_min: float,
         freq_min: float,
         *,
-        dynamically_traced_coords: bool = True,
+        dynamically_traced_coords: bool = False,
     ) -> Dimension:
     """Initialize a :class:`Dimension`.
 
@@ -37,7 +37,7 @@ def dim(
     dynamically_traced_coords : bool, optional
         Only relevant for use with JAX tracing. Whether the coordinate values
         should be dynamically traced such that the grid can be altered inside a
-        jitted function, by default True
+        jitted function, by default False
 
     Returns
     -------


### PR DESCRIPTION
Stacked PRs:
 * __->__#264
 * #263


--- --- ---

### Change dynamically_traced_coords default to False


Declaring the coords as jax pytree leaves causes a lot of surprising behavior if one is not intimately familiar with jax tracing.
For example if a dimension is passed past a tracing boundary twice those two instances will not be considered equal during tracing.
Also removes dynamically_traced_coords from bragg example.
