### PR TITLE
Adjust plot sizes in example notebooks

### DIFF
--- a/examples/Bragg_beam_splitter.ipynb
+++ b/examples/Bragg_beam_splitter.ipynb
@@ -248,7 +248,7 @@
     "from bokeh.plotting import figure, show\n",
     "# plot the energy trend during the imaginary time evolution\n",
     "plt = figure(\n",
-    "    width=800, height=400, min_border=50,\n",
+    "    width=700, height=400, min_border=50,\n",
     "    title=\"The potential versus the wave function's position grid\",\n",
     "    x_axis_label=\"x [m]\",\n",
     "    y_axis_label=\"Potential/hbar [Hz]\"\n",
@@ -421,7 +421,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.13.2"
+   "version": "3.13.5"
   },
   "orig_nbformat": 4
  },

--- a/examples/helpers.py
+++ b/examples/helpers.py
@@ -9,8 +9,8 @@ import fftarray as fa
 
 
 # global plot parameters for bokeh
-plt_width       = 450
-plt_height      = 400
+plt_width       = 370
+plt_height      = 260
 plt_line_width  = 2
 plt_border      =  50
 plt_color1      = "navy"
@@ -192,7 +192,9 @@ def plt_array_values_space_time(
             x_axis_label = "time [s]",
             y_axis_label = f"{space} coordinate [{unit}]",
             x_range=(float(time[0]), float(time[-1])),
-            y_range=plt_range
+            y_range=plt_range,
+            width=plt_width,
+            height=plt_height,
         )
         r = plot.image(
             image=[np.transpose(values)],


### PR DESCRIPTION
Stacked PRs:
 * #272
 * __->__#270


--- --- ---

### Adjust plot sizes in example notebooks


Otherwise the plots are too wide in the rendered documentation.
Additionally they were a bit unwieldy when working in the notebooks.
