### PR TITLE
Bragg Beam Splitter Example: Define freq_extent in a rotational frequency

### DIFF
--- a/examples/Bragg_beam_splitter.ipynb
+++ b/examples/Bragg_beam_splitter.ipynb
@@ -174,7 +174,7 @@
     "    pos_min = -50e-6,\n",
     "    pos_max = 50e-6,\n",
     "    freq_middle = 0.,\n",
-    "    freq_extent = 32*k_L,\n",
+    "    freq_extent = 32/lambda_L,\n",
     "    loose_params = [\"freq_extent\"],\n",
     ")\n",
     "\n",


### PR DESCRIPTION
Previously it used an angular frequency while `freq_extent` takes a circular frequency so frequency space was too large by a factor of 2 pi.
Closes #329, thank you to Matthew Glaysher for reporting it.