### PR TITLE
Fix test_full_array by no longer testing with array-api-strict

### DIFF
--- a/src/fftarray/_src/creation_functions.py
+++ b/src/fftarray/_src/creation_functions.py
@@ -226,7 +226,7 @@ def coords_from_arr(
 def full(
         dim: Union[Dimension, Iterable[Dimension]],
         space: Union[Space, Iterable[Space], Dict[str, Space]],
-        fill_value: Union[bool, int, float, complex, Any],
+        fill_value: Union[bool, int, float, complex],
         /,
         *,
         xp: Optional[Any] = None,

--- a/src/fftarray/_src/creation_functions.py
+++ b/src/fftarray/_src/creation_functions.py
@@ -242,15 +242,23 @@ def full(
     space:
         Specify the space(s) in which the returned Array is intialized.
         If given as a dictionary it must contain all dimensions passed into ``dim``.
+    fill_value:
+        Value which is written into the created array. This may also be an array API library
+        scalar from which xp is then deduced. This only works if the underlying library
+        supports this case which is not mandated by the standard but still in practice
+        supported by numpy, jax, cupy and torch.
     xp:
-        The Array API namespace to use for the created ``Array``.
+        The array API namespace to use for the created ``Array``.
         If it is None, ``array_api_compat.array_namespace(fill_value)`` is used.
         If that fails the default namespace from ``get_default_xp()`` is used.
-    dtype : Optional[Any]
+    dtype:
         The dtype to use for the returned Array.
         If the value is `None`, the dtype is inferred from ``fill_value``
-        according to the rules of the underlying Array API.
-
+        according to the rules of the underlying array API implementation.
+        Note that the Python array API standard does not define the exact precision
+        of the inferred dtype which is therefore defined by the underlying implementation.
+    device:
+        The device on which the created array is placed.
 
     Returns
     -------

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -96,6 +96,12 @@ XPS_DEVICE_PAIRS = [
     *XPS_NON_DEFAULT_DEVICE_PAIRS,
 ]
 
+XPS_DEVICE_PAIRS_NO_STRICT = [
+    (xp, device_param, res)
+    for xp, device_param, res in XPS_DEVICE_PAIRS
+    if xp != array_api_strict
+]
+
 def get_other_space(space: Union[fa.Space, Tuple[fa.Space, ...]]):
     """Returns the other space. If input space is "pos", "freq" is returned and
     vice versa. If space is a `Tuple[Space]`, a tuple is returned.

--- a/tests/unit/test_creation.py
+++ b/tests/unit/test_creation.py
@@ -11,9 +11,17 @@ import fftarray as fa
 from fftarray._src.compat_namespace import convert_xp
 
 from tests.helpers import (
-    XPS_WITH_DEFAULT_DEVICE_PAIRS, XPS_ROTATED_PAIRS, XPS_DEVICE_PAIRS, XPS_NON_DEFAULT_DEVICE_PAIRS,
-    get_dims, dtypes_names_pairs, dtype_names_numeric_core, DTYPE_NAME, get_test_array,
     assert_fa_array_exact_equal,
+    DTYPE_NAME,
+    dtype_names_numeric_core,
+    dtypes_names_pairs,
+    get_dims,
+    get_test_array,
+    XPS_DEVICE_PAIRS_NO_STRICT,
+    XPS_DEVICE_PAIRS,
+    XPS_NON_DEFAULT_DEVICE_PAIRS,
+    XPS_ROTATED_PAIRS,
+    XPS_WITH_DEFAULT_DEVICE_PAIRS,
 )
 
 def test_no_xp_conversion() -> None:
@@ -253,7 +261,9 @@ def test_full_scalar(
         eager=eager,
     )
 
-@pytest.mark.parametrize("xp, device_param, device_res", XPS_DEVICE_PAIRS)
+# This excludes array-api-strict since passing an array library scalar as fill-value is not mandated by the standard.
+# However all other libraries support this behavior, for which we test here.
+@pytest.mark.parametrize("xp, device_param, device_res", XPS_DEVICE_PAIRS_NO_STRICT)
 @pytest.mark.parametrize("init_dtype_name, direct_dtype_name", dtypes_names_pairs)
 @pytest.mark.parametrize("ndims", [0,1,2])
 @pytest.mark.parametrize("eager", [True, False])

--- a/tests/unit/test_creation.py
+++ b/tests/unit/test_creation.py
@@ -253,38 +253,6 @@ def test_full_scalar(
         eager=eager,
     )
 
-@pytest.mark.parametrize("xp, device_param, device_res", XPS_DEVICE_PAIRS)
-@pytest.mark.parametrize("init_dtype_name, direct_dtype_name", dtypes_names_pairs)
-@pytest.mark.parametrize("ndims", [0,1,2])
-@pytest.mark.parametrize("eager", [True, False])
-def test_full_array(
-        xp,
-        device_param: Optional[Any],
-        device_res: Any,
-        init_dtype_name: DTYPE_NAME,
-        direct_dtype_name: Optional[DTYPE_NAME],
-        ndims: int,
-        eager: bool,
-    ) -> None:
-    # Define xp array according to xp with fill_value using init_dtype_name
-    fill_value = xp.asarray(5, dtype=getattr(xp, init_dtype_name))
-
-    if direct_dtype_name is None:
-        direct_dtype = None
-    else:
-        # dtype is explicity specified in array creation,
-        # overwrites the default dtype of the array library.
-        direct_dtype = getattr(xp, direct_dtype_name)
-
-    check_full(
-        xp=xp,
-        device_param=device_param,
-        device_res=device_res,
-        fill_value=fill_value,
-        direct_dtype=direct_dtype,
-        ndims=ndims,
-        eager=eager,
-    )
 
 def check_full(
         xp,


### PR DESCRIPTION
array-api-strict added a check for this in version 2.5.